### PR TITLE
fix: Always require uncached modules if touched by Cody

### DIFF
--- a/packages/cody/src/lib/hooks/utils/fs-tree.ts
+++ b/packages/cody/src/lib/hooks/utils/fs-tree.ts
@@ -19,3 +19,8 @@ export const isNewFile = (path: string, tree: FsTree): boolean => {
 
   return isNewFile;
 }
+
+export const requireUncached = (module: string) => {
+  delete require.cache[require.resolve(module)];
+  return require(module);
+}

--- a/packages/cody/src/lib/hooks/utils/json-schema/resolve-ref.ts
+++ b/packages/cody/src/lib/hooks/utils/json-schema/resolve-ref.ts
@@ -2,10 +2,12 @@ import {RefSchema} from "./ref-schema";
 import {ValueObjectRuntimeInfo} from "@event-engine/messaging/value-object";
 import {CodyResponse, CodyResponseType, Node} from "@proophboard/cody-types";
 import {names} from "@event-engine/messaging/helpers";
-import {types} from "@app/shared/types";
 import {JSONSchema7} from "json-schema-to-ts";
+import {requireUncached} from "../fs-tree";
 
 export const resolveRef = (schema: RefSchema, parentSchema: JSONSchema7, node: Node): ValueObjectRuntimeInfo | CodyResponse => {
+  const {types} = requireUncached('@app/shared/types');
+
   const ref = schema['$ref'].replace('/definitions/', '')
     .split("/")
     .map(r => names(r).className)

--- a/packages/cody/src/lib/hooks/utils/prooph-board-info.ts
+++ b/packages/cody/src/lib/hooks/utils/prooph-board-info.ts
@@ -7,7 +7,7 @@ import {getSingleSource, isCodyError, nodeNameToPascalCase} from "@proophboard/c
 import {detectService} from "./detect-service";
 import {getVoMetadata} from "./value-object/get-vo-metadata";
 import {now} from "./time";
-import {isNewFile} from "./fs-tree";
+import {isNewFile, requireUncached} from "./fs-tree";
 import {namespaceToFilePath} from "./value-object/namespace";
 
 export const loadDescription = <D extends ProophBoardDescription>(node: Node, ctx: Context, tree: FsTree): D | CodyResponse => {
@@ -67,7 +67,7 @@ export const loadDescription = <D extends ProophBoardDescription>(node: Node, ct
   const fullPath = `${nodeTypeFilename}/${serviceFilename}${ns}${descFile}`;
 
   if(!isNewFile(`${src}/${fullPath}`, tree)) {
-    const desc = require(`${importNs}/${fullPath.slice(0,-3)}`);
+    const desc = requireUncached(`${importNs}/${fullPath.slice(0,-3)}`);
 
     for (const descKey in desc) {
       if(desc.hasOwnProperty(descKey)) {


### PR DESCRIPTION
This fixes the problem that type references cannot be resolved by Cody if the referenced type is generated in the same Cody session.

Cody did not recognize changes in the type registry because Node modules are cached by default after first require. A helper function that deletes the cache before the actual require call solves the issue.