### PR TITLE
fix: Add missing use query template

### DIFF
--- a/packages/cody/src/lib/hooks/on-document.ts
+++ b/packages/cody/src/lib/hooks/on-document.ts
@@ -102,6 +102,15 @@ export const onDocument: CodyHook<Context> = async (vo: Node, ctx: Context) => {
 
       withErrorCheck(registerQueryResolver, [service, vo, ctx, tree]);
 
+      generateFiles(tree, __dirname + '/query-files/fe', ctx.feSrc, {
+        tmpl: "",
+        service: serviceNames.fileName,
+        serviceNames,
+        voNames,
+        ns,
+        ...queryNames
+      });
+
       // Upsert View Component
       if(isList) {
         await asyncWithErrorCheck(upsertListViewComponent, [vo, voMeta, ctx, tree]);

--- a/packages/cody/src/lib/hooks/query-files/fe/queries/__service__/use-__fileName__.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/query-files/fe/queries/__service__/use-__fileName__.ts__tmpl__
@@ -1,0 +1,26 @@
+import {Api} from "@frontend/api";
+import {AxiosResponse} from "axios";
+import {useQuery} from "@tanstack/react-query";
+import {QueryError} from "@frontend/queries/error/query-error";
+import {<%= className %>} from "@app/shared/queries/<%= serviceNames.fileName %>/<%= fileName %>";
+import {<%= className %>Desc} from "@app/shared/queries/<%= serviceNames.fileName %>/<%= fileName %>.desc";
+import {<%= voNames.className %>} from "@app/shared/types/<%= serviceNames.fileName %><%= ns.fileName %><%= voNames.fileName %>";
+
+export const <%= propertyName %> = async (params: <%= className %>): Promise<<%= voNames.className %>> => {
+  const response: AxiosResponse<<%= voNames.className %>> = await Api.executeQuery(<%= className %>Desc.name, params);
+
+  if(response.status === 200) {
+    return response.data;
+  }
+
+  return Promise.reject(new QueryError(<%= className %>Desc.name));
+}
+
+export const use<%= className %> = (params: <%= className %>) => {
+  return useQuery({
+    queryKey: [<%= className %>Desc.name, params],
+    queryFn: (): Promise<<%= voNames.className %>> => {
+      return <%= propertyName %>(params);
+    }
+  })
+}


### PR DESCRIPTION
Code generation for a frontend query hook was missing, but view components expect them to be present. This PR fixes the bug by adding a template and integrating code generation for it into `on-document` Cody hook.