### PR TITLE
fix: Aggregate repository not registered

### DIFF
--- a/packages/cody/src/lib/hooks/on-aggregate.ts
+++ b/packages/cody/src/lib/hooks/on-aggregate.ts
@@ -10,7 +10,7 @@ import {generateFiles} from "@nx/devkit";
 import {getVoMetadata} from "./utils/value-object/get-vo-metadata";
 import {namespaceToFilePath, namespaceToJSONPointer} from "./utils/value-object/namespace";
 import {updateProophBoardInfo} from "./utils/prooph-board-info";
-import {register, registerCommandHandler} from "./utils/registry";
+import {register, registerAggregateRepository, registerCommandHandler} from "./utils/registry";
 import {listChangesForCodyResponse} from "./utils/fs-tree";
 import {alwaysRecordEvent} from "./utils/aggregate/always-record-event";
 import {convertRuleConfigToAggregateBehavior} from "./utils/rule-engine/convert-rule-config-to-behavior";
@@ -91,6 +91,7 @@ export const onAggregate: CodyHook<Context> = async (aggregate: Node, ctx: Conte
 
     withErrorCheck(register, [aggregate, ctx, tree]);
     withErrorCheck(registerCommandHandler, [service, aggregate, ctx, tree]);
+    withErrorCheck(registerAggregateRepository, [service, aggregate, ctx, tree]);
 
     const changes = tree.listChanges();
 

--- a/packages/cody/src/lib/hooks/on-command.ts
+++ b/packages/cody/src/lib/hooks/on-command.ts
@@ -65,6 +65,10 @@ export const onCommand: CodyHook<Context> = async (command: Node, ctx: Context) 
     generateFiles(tree, __dirname + '/command-files/shared', ctx.sharedSrc, {
       'tmpl': '',
       'service': serviceNames.fileName,
+      // Please note: The order of substitutions is important here, because ProophBoardInfo contains "aggregateName"
+      // but it's a combined name of Service.Aggregate. The template itself requires "aggregateName" without Service
+      // which is defined below and therefor has precedence over the variable from ProophBoardInfo
+      ...withErrorCheck(updateProophBoardInfo, [command, ctx, tree]),
       serviceNames,
       isAggregateCommand,
       newAggregate: meta.newAggregate,
@@ -73,7 +77,6 @@ export const onCommand: CodyHook<Context> = async (command: Node, ctx: Context) 
       toJSON,
       ...cmdNames,
       schema,
-      ...withErrorCheck(updateProophBoardInfo, [command, ctx, tree])
     });
 
     withErrorCheck(register, [command, ctx, tree]);

--- a/packages/cody/src/lib/hooks/utils/registry.ts
+++ b/packages/cody/src/lib/hooks/utils/registry.ts
@@ -129,7 +129,7 @@ export const register = (node: Node, ctx: Context, tree: FsTree): boolean | Cody
       registryPath = sharedRegistryPath('aggregates.ts');
       registryVarName = 'aggregates';
       entryId = `${serviceNames.className}.${arNames.className}`;
-      entryValue = importName = `${serviceNames.className}${arNames.className}Desc`;
+      entryValue = importName = `${serviceNames.className}${arNames.className}AggregateDesc`;
       importPath = `@app/shared/aggregates/${serviceNames.fileName}/${arNames.fileName}.desc`;
       break;
     case NodeType.event:
@@ -211,6 +211,31 @@ export const registerCommandHandler = (service: string, aggregate: Node, ctx: Co
 
 
   addRegistryEntry(registryPath, registryVarName, entryId, entryValue, importName, importPath, tree);
+
+  return true;
+}
+
+export const registerAggregateRepository = (service: string, aggregate: Node, ctx: Context, tree: FsTree): boolean | CodyResponse => {
+  const serviceNames = names(service);
+  const aggregateNames = names(aggregate.getName());
+
+  if(!isNewFile(
+    joinPathFragments('packages', 'be', 'src', 'repositories', serviceNames.fileName, aggregateNames.fileName, `repository.ts`),
+    tree
+  )
+  ) {
+    return true;
+  }
+
+  const registryPath = joinPathFragments('packages', 'be', 'src', 'repositories', 'index.ts');
+  const registryVarName = 'repositories';
+  const entryId = `${serviceNames.className}.${aggregateNames.className}`;
+  const entryValue = `${serviceNames.propertyName}${aggregateNames.className}`;
+  const importName = `${serviceNames.propertyName}${aggregateNames.className}`;
+  const importPath = `@server/repositories/${serviceNames.fileName}/${aggregateNames.fileName}/repository`;
+
+
+  addRegistryEntry(registryPath, registryVarName, entryId, entryValue, importName, importPath, tree, true);
 
   return true;
 }


### PR DESCRIPTION
When Cody adds a new aggregate to the system he also adds a repository for the aggregate. But the repository was not registered in the repository registry which caused a runtime error, when trying to send a command for that aggregate.

This PR fixes the problem.

Also fixed that aggregate name gets f**ed up in command description.