### PR TITLE
Feature/data select

### DIFF
--- a/packages/cody/src/lib/hooks/command-files/shared/commands/__service__/__fileName__.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/command-files/shared/commands/__service__/__fileName__.ts__tmpl__
@@ -5,6 +5,7 @@ import {CommandRuntimeInfo, makeCommand} from "@event-engine/messaging/command";
 import definitions from "@app/shared/types/definitions";
 import {references} from "@app/shared/types/references";
 import {<%= className %>Schema} from "@app/shared/commands/<%= service %>/<%= fileName %>.schema";
+import {<%= className %>UiSchema} from "@app/shared/commands/<%= service %>/<%= fileName %>.ui-schema";
 import {<%= className %>Desc} from "@app/shared/commands/<%= service %>/<%= fileName %>.desc";
 
 export type <%= className %> = DeepReadonly<FromSchema<
@@ -22,4 +23,5 @@ export const <%= serviceNames.className %><%= className %>RuntimeInfo: CommandRu
   desc: <%= className %>Desc,
   factory: <%= propertyName %>,
   schema: <%= className %>Schema,
+  uiSchema: <%= className %>UiSchema,
 }

--- a/packages/cody/src/lib/hooks/command-files/shared/commands/__service__/__fileName__.ui-schema.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/command-files/shared/commands/__service__/__fileName__.ui-schema.ts__tmpl__
@@ -1,0 +1,1 @@
+export const <%= className %>UiSchema = <%- toJSON(uiSchema) %> as const;

--- a/packages/cody/src/lib/hooks/on-command.ts
+++ b/packages/cody/src/lib/hooks/on-command.ts
@@ -20,13 +20,14 @@ import {updateProophBoardInfo} from "./utils/prooph-board-info";
 import {toJSON} from "./utils/to-json";
 import {register} from "./utils/registry";
 import {listChangesForCodyResponse} from "./utils/fs-tree";
-import {Writable} from "json-schema-to-ts/lib/types/type-utils";
+import {UiSchema} from "@rjsf/utils";
 
 interface CommandMeta {
   newAggregate: boolean;
   shorthand: boolean;
   schema: JSONSchema | ShorthandObject;
   service?: string;
+  uiSchema?: UiSchema;
 }
 
 export const onCommand: CodyHook<Context> = async (command: Node, ctx: Context) => {
@@ -46,6 +47,8 @@ export const onCommand: CodyHook<Context> = async (command: Node, ctx: Context) 
     if(typeof schema === "object" && !schema.hasOwnProperty('$id')) {
       schema['$id'] = `/definitions/${serviceNames.fileName}/commands/${cmdNames.fileName}`;
     }
+
+    const uiSchema = meta.uiSchema || {};
 
     const isAggregateCommand = !isCodyError(aggregate);
 
@@ -77,6 +80,7 @@ export const onCommand: CodyHook<Context> = async (command: Node, ctx: Context) 
       toJSON,
       ...cmdNames,
       schema,
+      uiSchema,
     });
 
     withErrorCheck(register, [command, ctx, tree]);

--- a/packages/cody/src/lib/hooks/ui-files/command-files/app/components/__service__/commands/__className__.tsx__tmpl__
+++ b/packages/cody/src/lib/hooks/ui-files/command-files/app/components/__service__/commands/__className__.tsx__tmpl__
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {useState} from "react";
-import CommandButton from "@frontend/app/components/core/CommandButton";
+import CommandButton, {WithCommandButtonProps} from '@frontend/app/components/core/CommandButton';
 import CommandDialog from "@frontend/app/components/core/CommandDialog";
 import {<%= propertyName %>} from "@frontend/commands/<%= serviceNames.fileName %>/use-<%= fileName %>";
 import {<%= serviceNames.className %><%= className %>RuntimeInfo} from "@app/shared/commands/<%= serviceNames.fileName %>/<%= fileName %>";
@@ -9,7 +9,7 @@ interface OwnProps {
 
 }
 
-type <%= className %>Props = OwnProps;
+type <%= className %>Props = OwnProps & WithCommandButtonProps;
 
 const <%= className %> = (props: <%= className %>Props) => {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -18,7 +18,7 @@ const <%= className %> = (props: <%= className %>Props) => {
   const handleCloseDialog = () => {setDialogOpen(false)};
 
   return <>
-    <CommandButton command={<%= serviceNames.className %><%= className %>RuntimeInfo} onClick={handleOpenDialog} />
+    <CommandButton command={<%= serviceNames.className %><%= className %>RuntimeInfo} onClick={handleOpenDialog} {...props.buttonProps} />
     <CommandDialog open={dialogOpen} onClose={handleCloseDialog} commandDialogCommand={<%= serviceNames.className %><%= className %>RuntimeInfo} commandFn={<%= propertyName %>} />
   </>
 };

--- a/packages/cody/src/lib/hooks/utils/ui/get-ui-metadata.ts
+++ b/packages/cody/src/lib/hooks/utils/ui/get-ui-metadata.ts
@@ -5,7 +5,7 @@ import {parseJsonMetadata} from "@proophboard/cody-utils";
 
 export interface DynamicBreadcrumbMetadata {
   data: string;
-  value: Rule[] | string;
+  label: Rule[] | string;
 }
 
 export interface UiMetadata {
@@ -20,7 +20,7 @@ export const isDynamicBreadcrumb = (breadcrumb: string | DynamicBreadcrumbMetada
     return false;
   }
 
-  if(breadcrumb.data && breadcrumb.value) {
+  if(breadcrumb.data && breadcrumb.label) {
     return true
   }
 

--- a/packages/cody/src/lib/hooks/utils/ui/upsert-page-definition.ts
+++ b/packages/cody/src/lib/hooks/utils/ui/upsert-page-definition.ts
@@ -203,7 +203,7 @@ const getBreadcrumb = (ui: Node, uiMeta: UiMetadata, ctx: Context): [string, str
     ]
   }
 
-  const {data, value} = breadcrumb;
+  const {data, label} = breadcrumb;
 
   const vo = getVOFromDataReference(data, ui, ctx);
 
@@ -220,7 +220,7 @@ const getBreadcrumb = (ui: Node, uiMeta: UiMetadata, ctx: Context): [string, str
 
   const serviceNames = names(service);
 
-  const valueGetterRules = convertRuleConfigToDynamicBreadcrumbValueGetterRules(ui, ctx, value, '    ');
+  const valueGetterRules = convertRuleConfigToDynamicBreadcrumbValueGetterRules(ui, ctx, label, '    ');
 
   const valueGetter = `(data) => {
     const ctx: any = { data, value: '' };

--- a/packages/cody/src/lib/hooks/vo-files/shared/types/__fileName__.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/vo-files/shared/types/__fileName__.ts__tmpl__
@@ -5,6 +5,7 @@ import {Writable} from "json-schema-to-ts/lib/types/type-utils";
 import definitions from "@app/shared/types/definitions";
 import {references} from "@app/shared/types/references";
 import {<%= className %>Schema} from "./<%= fileName %>.schema";
+import {<%= className %>UiSchema} from "./<%= fileName %>.ui-schema";
 import {<%= className %>Desc} from "./<%= fileName %>.desc";
 
 export type <%= className %> = DeepReadonly<FromSchema<
@@ -30,4 +31,5 @@ export const <%= serviceNames.className %><%= ns.className %><%= className %>VOR
   desc: <%= className %>Desc,
   factory: <%= propertyName %>,
   schema: <%= className %>Schema,
+  uiSchema: <%= className %>UiSchema,
 }

--- a/packages/cody/src/lib/hooks/vo-files/shared/types/__fileName__.ui-schema.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/vo-files/shared/types/__fileName__.ui-schema.ts__tmpl__
@@ -1,0 +1,1 @@
+export const <%= className %>UiSchema = <%- toJSON(meta.uiSchema || {}) %> as const;

--- a/packages/contribution/src/generators/prepare-contribution/files/fe/src/app/components/fleet-management/commands/AddCarToFleet.tsx
+++ b/packages/contribution/src/generators/prepare-contribution/files/fe/src/app/components/fleet-management/commands/AddCarToFleet.tsx
@@ -1,26 +1,39 @@
 import * as React from 'react';
-import {useState} from "react";
-import CommandButton from "@frontend/app/components/core/CommandButton";
-import {FleetManagementAddCarToFleetRuntimeInfo} from "@app/shared/commands/fleet-management/add-car-to-fleet";
-import CommandDialog from "@frontend/app/components/core/CommandDialog";
-import {addCarToFleet} from "@frontend/commands/fleet-management/use-add-car-to-fleet";
+import { useState } from 'react';
+import CommandButton, {WithCommandButtonProps} from '@frontend/app/components/core/CommandButton';
+import CommandDialog from '@frontend/app/components/core/CommandDialog';
+import { addCarToFleet } from '@frontend/commands/fleet-management/use-add-car-to-fleet';
+import { FleetManagementAddCarToFleetRuntimeInfo } from '@app/shared/commands/fleet-management/add-car-to-fleet';
 
-interface OwnProps {
+interface OwnProps {}
 
-}
-
-type AddCarToFleetProps = OwnProps;
+type AddCarToFleetProps = OwnProps & WithCommandButtonProps;
 
 const AddCarToFleet = (props: AddCarToFleetProps) => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const handleOpenDialog = () => {setDialogOpen(true)};
-  const handleCloseDialog = () => {setDialogOpen(false)};
+  const handleOpenDialog = () => {
+    setDialogOpen(true);
+  };
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+  };
 
-  return <>
-    <CommandButton command={FleetManagementAddCarToFleetRuntimeInfo} onClick={handleOpenDialog} />
-    <CommandDialog open={dialogOpen} onClose={handleCloseDialog} commandDialogCommand={FleetManagementAddCarToFleetRuntimeInfo} commandFn={addCarToFleet} />
-  </>
+  return (
+    <>
+      <CommandButton
+        command={FleetManagementAddCarToFleetRuntimeInfo}
+        onClick={handleOpenDialog}
+        {...props.buttonProps}
+      />
+      <CommandDialog
+        open={dialogOpen}
+        onClose={handleCloseDialog}
+        commandDialogCommand={FleetManagementAddCarToFleetRuntimeInfo}
+        commandFn={addCarToFleet}
+      />
+    </>
+  );
 };
 
 export default AddCarToFleet;

--- a/packages/fe/src/app/components/core/CommandButton.tsx
+++ b/packages/fe/src/app/components/core/CommandButton.tsx
@@ -16,7 +16,11 @@ interface OwnProps {
   variant?: "text" | "outlined" | "contained"
 }
 
-type CommandButtonProps = OwnProps;
+export type CommandButtonProps = OwnProps;
+
+export interface WithCommandButtonProps {
+  buttonProps?: Partial<CommandButtonProps>
+}
 
 export const commandTitle = (cmd: CommandRuntimeInfo): string => {
   let uiTitle;

--- a/packages/fe/src/app/components/core/form/widgets.ts
+++ b/packages/fe/src/app/components/core/form/widgets.ts
@@ -1,5 +1,8 @@
 import {Widget} from "@rjsf/utils";
+import DataSelectWidget from "@frontend/app/components/core/form/widgets/DataSelectWidget";
 
 export type WidgetRegistry = {[widgetName: string]: Widget};
 
-export const widgets: WidgetRegistry = {}
+export const widgets: WidgetRegistry = {
+  DataSelect: DataSelectWidget,
+}

--- a/packages/fe/src/app/components/core/form/widgets/DataSelectWidget.tsx
+++ b/packages/fe/src/app/components/core/form/widgets/DataSelectWidget.tsx
@@ -1,0 +1,101 @@
+import { ChangeEvent, FocusEvent } from 'react';
+import {
+  ariaDescribedByIds,
+  labelValue,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from '@rjsf/utils';
+import {MenuItem, TextField, TextFieldProps} from "@mui/material";
+
+// Copied from: https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+// and modified to use useApiQuery and turn result into select options
+
+export default function DataSelectWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+  >({
+      schema,
+      id,
+      options,
+      label,
+      hideLabel,
+      required,
+      disabled,
+      readonly,
+      placeholder,
+      value,
+      multiple,
+      autofocus,
+      onChange,
+      onBlur,
+      onFocus,
+      rawErrors = [],
+      registry,
+      uiSchema,
+      hideError,
+      formContext,
+      ...textFieldProps
+    }: WidgetProps<T, S, F>) {
+
+  // @TODO: Make sure that uiSchema is passed to CommandForm and StateView
+  // @TODO: Fetch data using useApiQuery
+  // @TODO: Inject "loading..." option with empty value while query is loading
+  // @TODO: use jexl to get label and value from fetched data
+
+  const selectOptions: {label: string, value: string}[] = [];
+
+
+  multiple = typeof multiple === 'undefined' ? false : !!multiple;
+
+  const emptyValue = multiple ? [] : '';
+  const isEmpty = typeof value === 'undefined' || (multiple && value.length < 1) || (!multiple && value === emptyValue);
+
+  const _onChange = ({ target: { value } }: ChangeEvent<{ value: string }>) =>
+    onChange(value);
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onBlur(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, value);
+
+  return (
+    <TextField
+      id={id}
+      name={id}
+      label={labelValue(label, hideLabel || !label, false)}
+      value={isEmpty ? emptyValue : value}
+      required={required}
+      disabled={disabled || readonly}
+      autoFocus={autofocus}
+      placeholder={placeholder}
+      error={rawErrors.length > 0}
+      onChange={_onChange}
+      onBlur={_onBlur}
+      onFocus={_onFocus}
+      {...(textFieldProps as TextFieldProps)}
+      select // Apply this and the following props after the potential overrides defined in textFieldProps
+      InputLabelProps={{
+        ...textFieldProps.InputLabelProps,
+        shrink: !isEmpty,
+      }}
+      SelectProps={{
+        ...textFieldProps.SelectProps,
+        multiple,
+      }}
+      aria-describedby={ariaDescribedByIds<T>(id)}
+    >
+      {Array.isArray(selectOptions) &&
+        selectOptions.map(({ value, label }, i: number) => {
+          return (
+            <MenuItem key={i} value={value} disabled={disabled || readonly}>
+              {label}
+            </MenuItem>
+          );
+        })}
+    </TextField>
+  );
+
+};
+


### PR DESCRIPTION
This PR ads a "DataSelectWidget" that can be used in a json-schema-form to fetch a "queryable state list" from the backend and turn every state item into a select option.

Here is an example usage within a "Add Model" command that fetches a list of "Brands" for a brand selectbox

_Add Model Metadata_

```json
{
  "newAggregate": true,
  "shorthand": true,
  "schema": {
    "modelId": "string",
    "brandId": "string|title:Brand",
    "name": "string"
  },
  "uiSchema": {
    "brandId": {
      "ui:widget": "DataSelect",
      "ui:options": {
        "data": "FleetManagement.Car.BrandList",
        "label": "data.name",
        "value": "data.brandId",
        "addItemCommand": "FleetManagement.AddBrand"
      }
    }
  }
}
```

Additionally, an "Add-Item-Command" can be configured to show a command button below the select box. The command should add a new state item that will become available in the select afterwards.