### PR TITLE
feat(projections): Support live projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ Useful during development to test new policies or trigger events in production a
 npx nx run be:republish --eventid <EventId>
 ```
 
+## Trigger Projection with event
+
+Useful during development to test new projections or trigger events in production again
+
+```shell
+npx nx run be:project --eventid <EventId> --name <ProjectionName>
+```
+
+`--name` is optional and defaults to: "read_model"
+
+
 ## Contribution
 
 This repository is a skeleton for a Cody Engine app that has batteries included. This means, that Cody will

--- a/packages/be/project.json
+++ b/packages/be/project.json
@@ -91,6 +91,24 @@
         }
       }
     },
+    "project": {
+      "executor": "nx:run-commands",
+      "defaultConfiguration": "development",
+      "options": {
+        "cwd": "packages/be",
+        "color": true,
+        "command": "npx ts-node -r tsconfig-paths/register src/infrastructure/run-projection.ts",
+        "buildTarget": "be:build"
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "be:build:development"
+        },
+        "production": {
+          "buildTarget": "be:build:production"
+        }
+      }
+    },
     "lint": {
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/be/src/extensions/services.ts.cetmpl
+++ b/packages/be/src/extensions/services.ts.cetmpl
@@ -1,6 +1,10 @@
 import {ServiceRegistry} from "@event-engine/infrastructure/ServiceRegistry";
 import {authServiceFactory} from "@server/infrastructure/auth-service/auth-service-factory";
+import {informationServiceFactory} from "@server/infrastructure/information-service/information-service-factory";
+import {getConfiguredMessageBox} from "@server/infrastructure/configuredMessageBox";
 
 export const services: ServiceRegistry = {
-  'AuthService': authServiceFactory
+  'AuthService': authServiceFactory,
+  // Default service that's always available when events are being handled. Used to update read models
+  'CodyInformationService': informationServiceFactory,
 };

--- a/packages/be/src/infrastructure/MessageBus.ts
+++ b/packages/be/src/infrastructure/MessageBus.ts
@@ -5,6 +5,7 @@ import {services} from "@server/extensions/services";
 import {Message} from "@event-engine/messaging/message";
 import {getConfiguredMessageBox} from "@server/infrastructure/configuredMessageBox";
 import jexl from "@app/shared/jexl/get-configured-jexl";
+import {INFORMATION_SERVICE_NAME} from "@server/infrastructure/information-service/information-service";
 
 export type MessageType = 'command' | 'event' | 'query';
 
@@ -14,7 +15,7 @@ export class MessageBus {
     const {dependencies} = desc;
     const loadedDependencies: Record<string, any> = {};
 
-    if(!dependencies) {
+    if(!dependencies && type !== 'event') {
       return loadedDependencies;
     }
 
@@ -55,6 +56,11 @@ export class MessageBus {
         default:
           throw new Error(`Unknown dependency type detected for "${message.name}". Supported dependency types are: "query", "service". But the configured type is "${dep.type}"`);
       }
+    }
+
+    // Always add Information Service so that read model rules can access it
+    if(type === "event") {
+      loadedDependencies[INFORMATION_SERVICE_NAME] = this.loadServiceDependency(INFORMATION_SERVICE_NAME, message, {});
     }
 
     return loadedDependencies;

--- a/packages/be/src/infrastructure/configuredEventBus.ts
+++ b/packages/be/src/infrastructure/configuredEventBus.ts
@@ -4,22 +4,50 @@ import {policies} from "@server/policies/index";
 import {MessageBus} from "@server/infrastructure/MessageBus";
 import {getConfiguredCommandBus, SERVICE_NAME_COMMAND_BUS} from "@server/infrastructure/configuredCommandBus";
 import {services} from "@server/extensions/services";
+import {EventBus} from "@event-engine/messaging/event-bus";
 
 export const SERVICE_NAME_EVENT_BUS = '$EventBus';
 
-class EventBus extends MessageBus {
-  public async on(event: Event): Promise<boolean> {
+class LiveEventBus extends MessageBus implements EventBus {
+  public async on(event: Event, triggerLiveProjections?: boolean): Promise<boolean> {
     const eventPolicies = {
       ...policies[event.name],
       ...extensionPolicies[event.name]
     }
 
-    console.log("[EventBus] Policies for event: ", event.name, eventPolicies);
+    const filteredPolicies = Object.values(eventPolicies).filter(({policy, desc}) => !!desc.live === !!triggerLiveProjections);
 
-    for (const {policy, desc} of Object.values(eventPolicies)) {
+    console.log("[EventBus] "+(triggerLiveProjections? 'Live Projections' : 'Policies')+" for event: ", event.name, filteredPolicies.map(({policy, desc}) => desc));
+
+    for (const {policy, desc} of filteredPolicies) {
       const dependencies = await this.loadDependencies(event, desc, 'event');
 
       dependencies[SERVICE_NAME_COMMAND_BUS] = services[SERVICE_NAME_COMMAND_BUS]? services[SERVICE_NAME_COMMAND_BUS]({}) : getConfiguredCommandBus();
+
+      if(triggerLiveProjections) {
+        await policy(event, dependencies);
+      } else {
+        policy(event, dependencies).catch(e => console.error(e));
+      }
+
+    }
+
+    return true;
+  }
+
+  public async runProjection(event: Event, projectionName: string): Promise<boolean> {
+    const eventPolicies = {
+      ...policies[event.name],
+      ...extensionPolicies[event.name]
+    }
+
+    const filteredPolicies = Object.values(eventPolicies)
+      .filter(({policy, desc}) => desc.projection && desc.projection === projectionName);
+
+    console.log(`[EventBus] Running projection ${projectionName} for event: `, event.name, filteredPolicies.map(({policy, desc}) => desc));
+
+    for (const {policy, desc} of filteredPolicies) {
+      const dependencies = await this.loadDependencies(event, desc, 'event');
 
       policy(event, dependencies).catch(e => console.error(e));
     }
@@ -28,11 +56,11 @@ class EventBus extends MessageBus {
   }
 }
 
-let eventBus: EventBus;
+let eventBus: LiveEventBus;
 
-export const getConfiguredEventBus = (): EventBus => {
+export const getConfiguredEventBus = (): LiveEventBus => {
   if(!eventBus) {
-    eventBus = new EventBus();
+    eventBus = new LiveEventBus();
   }
 
   return eventBus;

--- a/packages/be/src/infrastructure/configuredMessageBox.ts
+++ b/packages/be/src/infrastructure/configuredMessageBox.ts
@@ -4,14 +4,17 @@ import {CommandRuntimeInfo} from "@event-engine/messaging/command";
 import {EventRuntimeInfo} from "@event-engine/messaging/event";
 import {queries} from "@app/shared/queries";
 import {QueryRuntimeInfo} from "@event-engine/messaging/query";
-import {CommandBus, EventBus, QueryBus} from "@server/infrastructure/types";
 import {getExternalService} from "@server/extensions/get-external-service";
 import {getConfiguredCommandBus, SERVICE_NAME_COMMAND_BUS} from "@server/infrastructure/configuredCommandBus";
 import {getConfiguredQueryBus, SERVICE_NAME_QUERY_BUS} from "@server/infrastructure/configuredQueryBus";
 import {getConfiguredEventBus, SERVICE_NAME_EVENT_BUS} from "@server/infrastructure/configuredEventBus";
 import {Meta, Payload} from "@event-engine/messaging/message";
+import {CommandBus} from "@event-engine/messaging/command-bus";
+import {EventBus} from "@event-engine/messaging/event-bus";
+import {QueryBus} from "@event-engine/messaging/query-bus";
+import {MessageBox} from "@event-engine/messaging/message-box";
 
-class MessageBox {
+class InternalMessageBox implements MessageBox{
 
   public commandBus: CommandBus;
   public eventBus: EventBus;
@@ -87,7 +90,7 @@ let messageBox: MessageBox;
 
 export const getConfiguredMessageBox = (): MessageBox => {
   if(!messageBox) {
-    messageBox = new MessageBox();
+    messageBox = new InternalMessageBox();
   }
 
   return messageBox;

--- a/packages/be/src/infrastructure/configuredQueryBus.ts
+++ b/packages/be/src/infrastructure/configuredQueryBus.ts
@@ -3,10 +3,11 @@ import {QueryDescription} from "@event-engine/descriptions/descriptions";
 import {queryResolverExtensions} from "@server/extensions/query-resolvers";
 import {queryResolvers} from "@server/query-resolvers/index";
 import {Payload} from "@event-engine/messaging/message";
+import {QueryBus} from "@event-engine/messaging/query-bus";
 
 export const SERVICE_NAME_QUERY_BUS = '$QueryBus';
 
-class QueryBus {
+class LiveQueryBus implements QueryBus {
   public async dispatch<S extends Payload = any>(query: Query, desc: QueryDescription): Promise<S> {
     const resolver = this.getResolver<S>(desc);
     return await resolver(query);
@@ -25,11 +26,11 @@ class QueryBus {
   }
 }
 
-let queryBus: QueryBus;
+let queryBus: LiveQueryBus;
 
-export const getConfiguredQueryBus = (): QueryBus => {
+export const getConfiguredQueryBus = (): LiveQueryBus => {
   if(!queryBus) {
-    queryBus = new QueryBus();
+    queryBus = new LiveQueryBus();
   }
 
   return queryBus;

--- a/packages/be/src/infrastructure/information-service/document-store-information-service.ts
+++ b/packages/be/src/infrastructure/information-service/document-store-information-service.ts
@@ -1,0 +1,93 @@
+import {InformationService} from "@server/infrastructure/information-service/information-service";
+import {DocumentStore} from "@event-engine/infrastructure/DocumentStore";
+import {types} from "@app/shared/types";
+import {
+  isQueryableStateDescription,
+  isQueryableStateListDescription,
+  isQueryableValueObjectDescription
+} from "@event-engine/descriptions/descriptions";
+import {Session} from "@event-engine/infrastructure/MultiModelStore/Session";
+import {Filter} from "@event-engine/infrastructure/DocumentStore/Filter";
+
+export class DocumentStoreInformationService implements InformationService {
+  private ds: DocumentStore;
+  private session?: Session;
+
+  public constructor(ds: DocumentStore) {
+    this.ds = ds;
+  }
+
+  public useSession(session: Session): void {
+    this.session = session;
+  }
+
+  public forgetSession(): void {
+    this.session = undefined;
+  }
+
+  public async insert(informationName: string, id: string, data: object, metadata?: object, version?: number): Promise<void> {
+    const collectionName = this.detectCollection(informationName);
+
+    if(this.session) {
+      this.session.insertDocument(collectionName, id, data, metadata, version);
+      return;
+    }
+    return this.ds.addDoc(collectionName, id, data, metadata, version);
+  }
+
+  public async upsert(informationName: string, id: string, data: object, metadata?: object, version?: number): Promise<void> {
+    const collectionName = this.detectCollection(informationName);
+
+    if(this.session) {
+      this.session.upsertDocument(collectionName, id, data, metadata, version);
+      return;
+    }
+    return this.ds.upsertDoc(collectionName, id, data, metadata, version);
+  }
+
+  public async update(informationName: string, filter: Filter, data: object, metadata?: object, version?: number): Promise<void> {
+    const collectionName = this.detectCollection(informationName);
+
+    if (this.session) {
+      this.session.updateManyDocuments(collectionName, filter, data, metadata, version);
+      return;
+    }
+    return this.ds.updateMany(collectionName, filter, data, metadata, version);
+  }
+
+  public async replace(informationName: string, filter: Filter, data: object, metadata?: object, version?: number): Promise<void> {
+    const collectionName = this.detectCollection(informationName);
+
+    if(this.session) {
+      this.session.replaceManyDocuments(collectionName, filter, data, metadata, version);
+      return;
+    }
+    return this.ds.replaceMany(collectionName, filter, data, metadata, version);
+  }
+
+  public async delete(informationName: string, filter: Filter): Promise<void> {
+    const collectionName = this.detectCollection(informationName);
+
+    if(this.session) {
+      this.session.deleteManyDocuments(collectionName, filter);
+      return;
+    }
+    return this.ds.deleteMany(collectionName, filter);
+  }
+
+  private detectCollection(informationName: string): string {
+    const runtimeInfo = types[informationName];
+
+    if(!runtimeInfo) {
+      throw new Error(`Can't find the type: '${informationName}' in the type registry. Did you forget to pass the corresponding information card on prooph board to Cody?`);
+    }
+
+    const desc = runtimeInfo.desc;
+
+    if(!isQueryableStateDescription(desc) && !isQueryableStateListDescription(desc) && !isQueryableValueObjectDescription(desc) ) {
+      throw new Error(`The type: '${informationName}' is missing a 'collection' property in its type description. It cannot be stored in the read model database.`);
+    }
+
+    return desc.collection;
+  }
+}

--- a/packages/be/src/infrastructure/information-service/information-service-factory.ts
+++ b/packages/be/src/infrastructure/information-service/information-service-factory.ts
@@ -1,0 +1,19 @@
+import {InformationService} from "@server/infrastructure/information-service/information-service";
+import {getConfiguredDocumentStore} from "@server/infrastructure/configuredDocumentStore";
+import {
+  DocumentStoreInformationService
+} from "@server/infrastructure/information-service/document-store-information-service";
+
+let infoService: InformationService;
+
+export const informationServiceFactory = (): InformationService => {
+  if(infoService) {
+    return infoService;
+  }
+
+  const ds = getConfiguredDocumentStore();
+
+  infoService = new DocumentStoreInformationService(ds);
+
+  return infoService;
+}

--- a/packages/be/src/infrastructure/information-service/information-service.ts
+++ b/packages/be/src/infrastructure/information-service/information-service.ts
@@ -1,0 +1,14 @@
+import {Filter} from "@event-engine/infrastructure/DocumentStore/Filter";
+import {Session} from "@event-engine/infrastructure/MultiModelStore/Session";
+
+export const INFORMATION_SERVICE_NAME = 'CodyInformationService';
+
+export interface InformationService {
+  useSession: (session: Session) => void;
+  forgetSession: () => void;
+  insert: (informationName: string, id: string, data: object, metadata?: object, version?: number) => Promise<void>;
+  upsert: (informationName: string, id: string, data: object, metadata?: object, version?: number) => Promise<void>;
+  update: (informationName: string, filter: Filter, data: object, metadata?: object, version?: number) => Promise<void>;
+  replace: (informationName: string, filter: Filter, data: object, metadata?: object, version?: number) => Promise<void>;
+  delete: (informationName: string, filter: Filter) => Promise<void>;
+}

--- a/packages/be/src/infrastructure/run-projection.ts
+++ b/packages/be/src/infrastructure/run-projection.ts
@@ -1,0 +1,35 @@
+import {getConfiguredMessageBox} from "@server/infrastructure/configuredMessageBox";
+import {getConfiguredEventStore, PUBLIC_STREAM, WRITE_MODEL_STREAM} from "@server/infrastructure/configuredEventStore";
+import * as process from "process";
+import {Command} from "commander";
+import {DEFAULT_READ_MODEL_PROJECTION} from "@event-engine/infrastructure/Projection/types";
+import {getConfiguredEventBus} from "@server/infrastructure/configuredEventBus";
+
+// Do not remove messageBox, without that import the script fails
+// Somehow ts-node is not able to load the event store module correctly
+// Doing the message box import first solves the problem
+// It seems to be a strange import ordering problem
+// @TODO: Find solution without import workaround
+const messageBox = getConfiguredMessageBox();
+const eventStore = getConfiguredEventStore();
+const eventBus = getConfiguredEventBus();
+
+const commander = new Command('project');
+
+commander.version('1.0.0', '-v, --version')
+  .usage('[OPTIONS]...')
+  .option('-i, --eventid <EventId>', 'Id of event to project into read model')
+  .option('-n, --name <ProjectionName>', `Name of the projection to run (default: ${DEFAULT_READ_MODEL_PROJECTION})`, DEFAULT_READ_MODEL_PROJECTION)
+  .parse(process.argv);
+
+const options = commander.opts();
+
+if(options.eventid) {
+  (async () => {
+    const events = await eventStore.load(WRITE_MODEL_STREAM, {'$eventId': options.eventid})
+
+    for await (const event of events) {
+      await eventBus.runProjection(event, options.name);
+    }
+  })().catch(e => console.error(e));
+}

--- a/packages/be/src/infrastructure/types.ts
+++ b/packages/be/src/infrastructure/types.ts
@@ -1,7 +1,0 @@
-import {getConfiguredCommandBus} from "@server/infrastructure/configuredCommandBus";
-import {getConfiguredEventBus} from "@server/infrastructure/configuredEventBus";
-import {getConfiguredQueryBus} from "@server/infrastructure/configuredQueryBus";
-
-export type CommandBus = ReturnType<typeof getConfiguredCommandBus>;
-export type EventBus = ReturnType<typeof getConfiguredEventBus>;
-export type QueryBus = ReturnType<typeof getConfiguredQueryBus>;

--- a/packages/be/src/repositories/index.ts.cetmpl
+++ b/packages/be/src/repositories/index.ts.cetmpl
@@ -1,6 +1,6 @@
 import {AggregateRepository} from "@event-engine/infrastructure/AggregateRepository";
 
-type RepositoryRegistry = {[aggregateName: string]: AggregateRepository<any>};
+type RepositoryRegistry = {[aggregateName: string]: () => AggregateRepository<any>};
 
 export const repositories: RepositoryRegistry = {
 }

--- a/packages/cody/src/lib/hooks/aggregate-files/be/repositories/__service__/__aggregate__/repository.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/aggregate-files/be/repositories/__service__/__aggregate__/repository.ts__tmpl__
@@ -7,19 +7,36 @@ import {<%= aggregateStateNames.className %>, <%= aggregateStateNames.propertyNa
 import {eventReducerExtensions} from "@server/extensions/event-reducers";
 import {getExternalServiceOrThrow} from "@server/extensions/get-external-service";
 import {AuthService} from "@server/infrastructure/auth-service/auth-service";
+import {
+  INFORMATION_SERVICE_NAME,
+  InformationService
+} from "@server/infrastructure/information-service/information-service";
+import {getConfiguredMessageBox} from "@server/infrastructure/configuredMessageBox";
 
-const store = getConfiguredMultiModelStore();
-const authService = getExternalServiceOrThrow<AuthService>('AuthService', {});
+let repository: AggregateRepository<<%= aggregateStateNames.className %>>;
 
-const repository = new AggregateRepository<<%= aggregateStateNames.className %>>(
-  store,
-  <%= serviceNames.className %><%= className %>AggregateDesc.stream || WRITE_MODEL_STREAM,
-  <%= serviceNames.className %><%= className %>AggregateDesc.collection,
-  <%= serviceNames.className %><%= className %>AggregateDesc.name,
-  <%= serviceNames.className %><%= className %>AggregateDesc.identifier,
-  {...applyFunctions, ...eventReducerExtensions},
-  <%= aggregateStateNames.propertyName %>,
-  authService
-);
+const factory = (): AggregateRepository<<%= aggregateStateNames.className %>> => {
+  if(!repository) {
+    const store = getConfiguredMultiModelStore();
+    const authService = getExternalServiceOrThrow<AuthService>('AuthService', {});
+    const infoService = getExternalServiceOrThrow<InformationService>(INFORMATION_SERVICE_NAME, {});
+    const messageBox = getConfiguredMessageBox();
 
-export default repository;
+    repository = new AggregateRepository<<%= aggregateStateNames.className %>>(
+      store,
+      <%= serviceNames.className %><%= className %>AggregateDesc.stream || WRITE_MODEL_STREAM,
+      <%= serviceNames.className %><%= className %>AggregateDesc.collection,
+      <%= serviceNames.className %><%= className %>AggregateDesc.name,
+      <%= serviceNames.className %><%= className %>AggregateDesc.identifier,
+      {...applyFunctions, ...eventReducerExtensions},
+      <%= aggregateStateNames.propertyName %>,
+      authService,
+      infoService,
+      messageBox
+    );
+  }
+
+  return repository;
+}
+
+export default factory;

--- a/packages/cody/src/lib/hooks/on-policy.ts
+++ b/packages/cody/src/lib/hooks/on-policy.ts
@@ -13,6 +13,14 @@ import {alwaysTriggerCommand} from "./utils/policy/always-trigger-command";
 import {convertRuleConfigToPolicyRules} from "./utils/rule-engine/convert-rule-config-to-behavior";
 import {toJSON} from "./utils/to-json";
 import {PolicyMeta} from "@cody-engine/cody/hooks/utils/policy/metadata";
+import {visitRulesThen} from "@cody-engine/cody/hooks/utils/rule-engine/visit-rule-then";
+import {
+  isDeleteInformation,
+  isInsertInformation, isReplaceInformation,
+  isUpdateInformation,
+  isUpsertInformation
+} from "@cody-engine/cody/hooks/utils/rule-engine/configuration";
+import {DEFAULT_READ_MODEL_PROJECTION} from "@event-engine/infrastructure/Projection/types";
 
 export const onPolicy: CodyHook<Context> = async (policy: Node, ctx: Context): Promise<CodyResponse> => {
   try {
@@ -21,8 +29,27 @@ export const onPolicy: CodyHook<Context> = async (policy: Node, ctx: Context): P
     const service = withErrorCheck(detectService, [policy, ctx]);
     const serviceNames = names(service);
     const dependencies = meta.dependencies;
+    const isLiveProjection = !!meta.live;
 
     const rules = meta.rules || [];
+
+    let isProjection = false;
+
+    visitRulesThen(rules, then => {
+      switch (true) {
+        case isInsertInformation(then):
+        case isUpsertInformation(then):
+        case isUpdateInformation(then):
+        case isReplaceInformation(then):
+        case isDeleteInformation(then):
+          isProjection = true;
+          break
+      }
+
+      return then;
+    })
+
+    const projectionName = isProjection? meta.projection || DEFAULT_READ_MODEL_PROJECTION : undefined;
 
     if(rules.length === 0) {
       const commands = withErrorCheck(getTargetsOfType, [policy, NodeType.command, true, false, true]);
@@ -55,6 +82,9 @@ export const onPolicy: CodyHook<Context> = async (policy: Node, ctx: Context): P
       dependencies,
       ...policyNames,
       behavior,
+      isProjection,
+      isLiveProjection,
+      projectionName,
       toJSON,
     });
 

--- a/packages/cody/src/lib/hooks/policy-files/be/policies/__service__/__fileName__.desc.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/policy-files/be/policies/__service__/__fileName__.desc.ts__tmpl__
@@ -3,6 +3,8 @@ import {PolicyDescription} from "@event-engine/descriptions/descriptions";
 export const <%= serviceNames.className %><%= className %>PolicyDesc: PolicyDescription = {
   name: '<%= serviceNames.className %>.<%= className %>',
   <% if (dependencies) { %>dependencies: <%- toJSON(dependencies) %>,<% } %>
+  <% if (isProjection) { %>projection: '<%= projectionName %>',<% } %>
+  <% if (isProjection) { %>live: <% if (isLiveProjection) { %>true<% } else { %>false<% } %>,<% } %>
   _pbBoardId: "<%= _pbBoardId %>",
   _pbCardId: "<%= _pbCardId %>",
   _pbCreatedBy: "<%= _pbCreatedBy %>",

--- a/packages/cody/src/lib/hooks/policy-files/be/policies/__service__/__fileName__.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/policy-files/be/policies/__service__/__fileName__.ts__tmpl__
@@ -2,6 +2,7 @@ import {Event} from "@event-engine/messaging/event";
 import {Policy} from "@event-engine/infrastructure/PolicyRegistry";
 import {getConfiguredMessageBox} from "@server/infrastructure/configuredMessageBox";
 import jexl from "@app/shared/jexl/get-configured-jexl";
+import {filters} from "@event-engine/infrastructure/DocumentStore/Filter/index";
 
 export const <%= propertyName %>: Policy = async (event: Event, deps: any) => {
   const messageBox = getConfiguredMessageBox();

--- a/packages/cody/src/lib/hooks/utils/policy/metadata.ts
+++ b/packages/cody/src/lib/hooks/utils/policy/metadata.ts
@@ -5,4 +5,6 @@ export interface PolicyMeta {
   service?: string;
   dependencies?: DependencyRegistry;
   rules?: Rule[];
+  live?: boolean;
+  projection?: string;
 }

--- a/packages/cody/src/lib/hooks/utils/rule-engine/configuration.ts
+++ b/packages/cody/src/lib/hooks/utils/rule-engine/configuration.ts
@@ -33,7 +33,8 @@ export const isIfNotConditionRule = (rule: any): rule is IfNotConditionRule => {
   return typeof rule.if_not !== "undefined";
 }
 
-export type ThenType = ThenRecordEvent | ThenThrowError | ThenAssignVariable | ThenTriggerCommand | ThenCallService | ThenFetchData | ThenExecuteRules | ThenForEach | ThenFilter;
+export type ThenType = ThenRecordEvent | ThenThrowError | ThenAssignVariable | ThenTriggerCommand | ThenCallService | ThenFetchData | ThenExecuteRules | ThenForEach
+  | ThenFilter | ThenInsertInformation | ThenUpsertInformation | ThenUpdateInformation | ThenReplaceInformation | ThenDeleteInformation;
 
 export type PropMapping = {[name: string]: string | string[]};
 
@@ -116,6 +117,63 @@ export interface ThenFetchData {
 
 export const isFetchData = (then: any): then is ThenFetchData => typeof then.fetch !== 'undefined';
 
+export interface ThenInsertInformation {
+  insert: {
+    information: string;
+    id: string;
+    set: string | PropMapping;
+    metadata?: string | PropMapping;
+    version?: number;
+  }
+}
+
+export const isInsertInformation = (then: any): then is ThenInsertInformation => typeof then.insert !== 'undefined';
+
+export interface ThenUpsertInformation {
+  upsert: {
+    information: string;
+    id: string;
+    set: string | PropMapping;
+    metadata?: string | PropMapping;
+    version?: number;
+  }
+}
+
+export const isUpsertInformation = (then: any): then is ThenUpsertInformation => typeof then.upsert !== 'undefined';
+
+export interface ThenUpdateInformation {
+  update: {
+    information: string;
+    filter: Filter;
+    set: string | PropMapping;
+    metadata?: string | PropMapping;
+    version?: number;
+  }
+}
+
+export const isUpdateInformation = (then: any): then is ThenUpdateInformation => typeof then.update !== 'undefined';
+
+export interface ThenReplaceInformation {
+  replace: {
+    information: string;
+    filter: Filter;
+    set: string | PropMapping;
+    metadata?: string | PropMapping;
+    version?: number;
+  }
+}
+
+export const isReplaceInformation = (then: any): then is ThenReplaceInformation => typeof then.replace !== 'undefined';
+
+export interface ThenDeleteInformation {
+  delete: {
+    information: string;
+    filter: Filter;
+  }
+}
+
+export const isDeleteInformation = (then: any): then is ThenDeleteInformation => typeof then.delete !== 'undefined';
+
 export interface ThenExecuteRules {
   execute: {
     rules: Rule[]
@@ -123,3 +181,5 @@ export interface ThenExecuteRules {
 }
 
 export const isExecuteRules = (then: any): then is ThenExecuteRules => typeof then.execute !== 'undefined';
+
+

--- a/packages/cody/src/lib/hooks/utils/rule-engine/visit-rule-then.ts
+++ b/packages/cody/src/lib/hooks/utils/rule-engine/visit-rule-then.ts
@@ -1,0 +1,40 @@
+import {
+  isExecuteRules, isForEach,
+  isIfConditionRule,
+  isIfNotConditionRule, isRecordEvent,
+  Rule,
+  ThenType
+} from "@cody-engine/cody/hooks/utils/rule-engine/configuration";
+import {names} from "@event-engine/messaging/helpers";
+import {normalizeThenRecordEventRules} from "@cody-play/infrastructure/rule-engine/normalize-then-record-event-rules";
+
+type Visitor = (then: ThenType) => ThenType;
+export const visitRulesThen = (rules: Rule[], visitor: Visitor): Rule[] => {
+  return rules.map(rule => visitRuleThen(rule, visitor));
+}
+
+export const visitRuleThen = (rule: Rule, visitor: Visitor): Rule => {
+  const clonedRule = {...rule};
+  if(isIfConditionRule(rule) || isIfNotConditionRule(rule)) {
+    if(rule.else && (isIfConditionRule(clonedRule) || isIfNotConditionRule(clonedRule))) {
+      clonedRule.else = visitThen(rule.else, visitor);
+    }
+  }
+  clonedRule.then = visitThen(rule.then, visitor);
+
+  return clonedRule;
+}
+
+const visitThen = (then: ThenType, visitor: Visitor): ThenType => {
+  then = visitor(then);
+
+  if(isExecuteRules(then)) {
+    return {execute: {rules: visitRulesThen(then.execute.rules, visitor)}};
+  }
+
+  if(isForEach(then)) {
+    return {forEach: {then: visitThen(then.forEach.then, visitor), variable: then.forEach.variable}};
+  }
+
+  return then;
+}

--- a/packages/cody/src/lib/hooks/utils/value-object/vo-registry-id.ts
+++ b/packages/cody/src/lib/hooks/utils/value-object/vo-registry-id.ts
@@ -1,0 +1,28 @@
+import {CodyResponse, Node} from "@proophboard/cody-types";
+import {Context} from "@cody-engine/cody/hooks/context";
+import {detectService} from "@cody-engine/cody/hooks/utils/detect-service";
+import {names} from "@event-engine/messaging/helpers";
+import {isCodyError} from "@proophboard/cody-utils";
+import {getVoMetadata} from "@cody-engine/cody/hooks/utils/value-object/get-vo-metadata";
+import {namespaceToJSONPointer} from "@cody-engine/cody/hooks/utils/value-object/namespace";
+
+export const voRegistryId = (vo: Node, ctx: Context): string | CodyResponse => {
+  const service = detectService(vo, ctx);
+
+  if(isCodyError((service))) {
+    return service;
+  }
+
+  const serviceNames = names(service);
+
+  const voNames = names(vo.getName());
+  const voMeta = getVoMetadata(vo, ctx);
+
+  if(isCodyError(voMeta)) {
+    return voMeta;
+  }
+
+  const nsJSONPointer = namespaceToJSONPointer(voMeta.ns);
+
+  return `${serviceNames.className}${nsJSONPointer}${voNames.className}`;
+}

--- a/packages/contribution/src/generators/prepare-contribution/files/be/src/query-resolvers/fleet-management/resolve-get-car-list.ts
+++ b/packages/contribution/src/generators/prepare-contribution/files/be/src/query-resolvers/fleet-management/resolve-get-car-list.ts
@@ -12,11 +12,11 @@ import {asyncMap} from "@event-engine/infrastructure/helpers/async-map";
 export const resolveGetCarList = async (query: Query<GetCarList>): Promise<CarList> => {
   const ds = getConfiguredDocumentStore();
 
-  const cursor = await ds.findDocs<{state: Car}>(
+  const cursor = await ds.findDocs<Car>(
     CarListDesc.collection,
     new AnyFilter()
   );
-  
-  return asyncIteratorToArray(asyncMap(cursor, ([,d]) => car(d.state)));
+
+  return asyncIteratorToArray(asyncMap(cursor, ([,d]) => car(d)));
 
 }

--- a/packages/contribution/src/generators/prepare-contribution/files/be/src/query-resolvers/fleet-management/resolve-get-car.ts
+++ b/packages/contribution/src/generators/prepare-contribution/files/be/src/query-resolvers/fleet-management/resolve-get-car.ts
@@ -8,12 +8,12 @@ import {CarDesc} from "@app/shared/types/fleet-management/car/car.desc";
 export const resolveGetCar = async (query: Query<GetCar>): Promise<Car> => {
   const ds = getConfiguredDocumentStore();
 
-  const doc = await ds.getDoc<{state: Car}>(CarDesc.collection, query.payload.vehicleId);
-  
+  const doc = await ds.getDoc<Car>(CarDesc.collection, query.payload.vehicleId);
+
   if(!doc) {
     throw new NotFoundError(`Car with vehicleId: "${query.payload.vehicleId}" not found!`);
   }
-  
-  return car(doc.state);
+
+  return car(doc);
 
 }

--- a/packages/contribution/src/generators/prepare-contribution/files/be/src/repositories/fleet-management/car/repository.ts
+++ b/packages/contribution/src/generators/prepare-contribution/files/be/src/repositories/fleet-management/car/repository.ts
@@ -7,19 +7,37 @@ import {Car, car} from "@app/shared/types/fleet-management/car/car";
 import {eventReducerExtensions} from "@server/extensions/event-reducers";
 import {getExternalServiceOrThrow} from "@server/extensions/get-external-service";
 import {AuthService} from "@server/infrastructure/auth-service/auth-service";
+import {
+  INFORMATION_SERVICE_NAME,
+  InformationService
+} from "@server/infrastructure/information-service/information-service";
+import {getConfiguredMessageBox} from "@server/infrastructure/configuredMessageBox";
 
-const store = getConfiguredMultiModelStore();
-const authService = getExternalServiceOrThrow<AuthService>('AuthService', {});
+let repository: AggregateRepository<Car>;
 
-const repository = new AggregateRepository<Car>(
-  store,
-  FleetManagementCarAggregateDesc.stream || WRITE_MODEL_STREAM,
-  FleetManagementCarAggregateDesc.collection,
-  FleetManagementCarAggregateDesc.name,
-  FleetManagementCarAggregateDesc.identifier,
-  {...applyFunctions, ...eventReducerExtensions},
-  car,
-  authService
-);
+const factory = (): AggregateRepository<Car> => {
+  if(!repository) {
+    const store = getConfiguredMultiModelStore();
+    const authService = getExternalServiceOrThrow<AuthService>('AuthService', {});
+    const infoService = getExternalServiceOrThrow<InformationService>(INFORMATION_SERVICE_NAME, {});
+    const messageBox = getConfiguredMessageBox();
 
-export default repository;
+    repository = new AggregateRepository<Car>(
+      store,
+      FleetManagementCarAggregateDesc.stream || WRITE_MODEL_STREAM,
+      FleetManagementCarAggregateDesc.collection,
+      FleetManagementCarAggregateDesc.name,
+      FleetManagementCarAggregateDesc.identifier,
+      {...applyFunctions, ...eventReducerExtensions},
+      car,
+      authService,
+      infoService,
+      messageBox
+    );
+  }
+
+  return repository;
+}
+
+
+export default factory;

--- a/packages/contribution/src/generators/prepare-contribution/files/be/src/repositories/index.ts
+++ b/packages/contribution/src/generators/prepare-contribution/files/be/src/repositories/index.ts
@@ -1,7 +1,7 @@
 import {AggregateRepository} from "@event-engine/infrastructure/AggregateRepository";
 import fleetManagementCarRepository from "@server/repositories/fleet-management/car/repository";
 
-type RepositoryRegistry = {[aggregateName: string]: AggregateRepository<any>};
+type RepositoryRegistry = {[aggregateName: string]: () => AggregateRepository<any>};
 
 export const repositories: RepositoryRegistry = {
   "FleetManagement.Car": fleetManagementCarRepository,

--- a/packages/descriptions/src/lib/descriptions.ts
+++ b/packages/descriptions/src/lib/descriptions.ts
@@ -66,6 +66,8 @@ export interface QueryDescription extends ProophBoardDescription {
 export interface PolicyDescription extends ProophBoardDescription {
   name: string;
   dependencies?: DependencyRegistry;
+  live?: boolean;
+  projection?: string;
 }
 
 export interface ValueObjectDescriptionFlags {

--- a/packages/fe/src/app/components/core/CommandForm.tsx
+++ b/packages/fe/src/app/components/core/CommandForm.tsx
@@ -29,6 +29,7 @@ import {types} from "@app/shared/types";
 import {getRjsfValidator} from "@frontend/util/rjsf-validator";
 import {DeepReadonly} from "json-schema-to-ts/lib/types/type-utils/readonly";
 import {JSONSchema7} from "json-schema";
+import {cloneDeepJSON} from "@frontend/util/clone-deep-json";
 
 interface OwnProps {
   command: CommandRuntimeInfo;
@@ -107,7 +108,7 @@ const CommandForm = (props: CommandFormProps, ref: any) => {
   }
 
   const handleSubmit = (e: IChangeEvent<any>) => {
-    let formData = e.formData;
+    let formData = cloneDeepJSON(e.formData);
     if(props.onBeforeSubmitting) {
       formData = props.onBeforeSubmitting(formData);
     }

--- a/packages/infrastructure/src/lib/DocumentStore.ts
+++ b/packages/infrastructure/src/lib/DocumentStore.ts
@@ -18,19 +18,21 @@ export interface DocumentStore {
   hasCollectionIndex: (collectionName: string, index: Index) => Promise<boolean>;
   dropCollectionIndex: (collectionName: string, index: Index) => Promise<void>;
 
-  addDoc: (collectionName: string, docId: string, doc: object, metadata?: object) => Promise<void>;
-  updateDoc: (collectionName: string, docId: string, docOrSubset: object, metadata?: object) => Promise<void>;
-  upsertDoc: (collectionName: string, docId: string, docOrSubset: object, metadata?: object) => Promise<void>;
-  replaceDoc: (collectionName: string, docId: string, doc: object, metadata?: object) => Promise<void>;
+  addDoc: (collectionName: string, docId: string, doc: object, metadata?: object, version?: number) => Promise<void>;
+  updateDoc: (collectionName: string, docId: string, docOrSubset: object, metadata?: object, version?: number) => Promise<void>;
+  upsertDoc: (collectionName: string, docId: string, docOrSubset: object, metadata?: object, version?: number) => Promise<void>;
+  replaceDoc: (collectionName: string, docId: string, doc: object, metadata?: object, version?: number) => Promise<void>;
   getDoc: <D extends object>(collectionName: string, docId: string) => Promise<D | null>;
   getPartialDoc: <D extends object>(collectionName: string, docId: string, partialSelect: PartialSelect) => Promise<D | null>;
+  getDocAndVersion: <D extends object>(collectionName: string, docId: string) => Promise<{doc: D, version: number} | null>;
+  getDocVersion: (collectionName: string, docId: string) => Promise<number | null>;
   deleteDoc: (collectionName: string, docId: string) => Promise<void>;
 
-  updateMany: (collectionName: string, filter: any, docOrSubset: object, metadata?: object) => Promise<void>;
-  replaceMany: (collectionName: string, filter: any, doc: object, metadata?: object) => Promise<void>;
+  updateMany: (collectionName: string, filter: Filter, docOrSubset: object, metadata?: object, version?: number) => Promise<void>;
+  replaceMany: (collectionName: string, filter: Filter, doc: object, metadata?: object, version?: number) => Promise<void>;
   deleteMany: (collectionName: string, filter: Filter) => Promise<void>;
-  findDocs: <D extends object>(collectionName: string, filter: Filter, skip?: number, limit?: number, orderBy?: SortOrder) => Promise<AsyncIterable<[string, D]>>;
-  findPartialDocs: <D extends object>(collectionName: string, partialSelect: PartialSelect, filter: Filter, skip?: number, limit?: number, orderBy?: SortOrder) => Promise<AsyncIterable<[string, D]>>;
+  findDocs: <D extends object>(collectionName: string, filter: Filter, skip?: number, limit?: number, orderBy?: SortOrder) => Promise<AsyncIterable<[string, D, number]>>;
+  findPartialDocs: <D extends object>(collectionName: string, partialSelect: PartialSelect, filter: Filter, skip?: number, limit?: number, orderBy?: SortOrder) => Promise<AsyncIterable<[string, D, number]>>;
   findDocIds: (collectionName: string, filter: Filter, skip?: number, limit?: number, orderBy?: SortOrder) => Promise<string[]>;
   countDocs: (collectionName: string, filter: Filter) => Promise<number>;
 }

--- a/packages/infrastructure/src/lib/DocumentStore/PostgresDocumentStore.spec.ts
+++ b/packages/infrastructure/src/lib/DocumentStore/PostgresDocumentStore.spec.ts
@@ -1,5 +1,4 @@
 import {PostgresDocumentStore} from "@event-engine/infrastructure/DocumentStore/PostgresDocumentStore";
-import {getConfiguredDB} from "@app/core/configuredDB";
 import {AnyFilter} from "@event-engine/infrastructure/DocumentStore/Filter/AnyFilter";
 import {Filter} from "@event-engine/infrastructure/DocumentStore/Filter";
 import {EqFilter} from "@event-engine/infrastructure/DocumentStore/Filter/EqFilter";
@@ -20,6 +19,7 @@ import {PartialSelect, SortOrder} from "@event-engine/infrastructure/DocumentSto
 import {FieldIndex} from "@event-engine/infrastructure/DocumentStore/Index/FieldIndex";
 import {MultiFieldIndex} from "@event-engine/infrastructure/DocumentStore/Index/MultiFieldIndex";
 import {MetadataFieldIndex} from "@event-engine/infrastructure/DocumentStore/Index/MetadataFieldIndex";
+import {getConfiguredDB} from "@server/infrastructure/configuredDB";
 
 describe('PostgresDocumentStore', () => {
   const db = getConfiguredDB();
@@ -91,7 +91,7 @@ describe('PostgresDocumentStore', () => {
 
   const getCollectionColumnsHelper = async (collection: string): Promise<string[]> => {
     const query = `SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name='${collection}'`;
-    return (await db.query(query)).rows.map(row => row['column_name']);
+    return (await db.query(query)).rows.map((row: any) => row['column_name']);
   };
 
   beforeEach(async () => {

--- a/packages/infrastructure/src/lib/EventStore.ts
+++ b/packages/infrastructure/src/lib/EventStore.ts
@@ -23,7 +23,7 @@ export function checkMatchObject(matcher: string | MatchObject): MatchObject {
     return matcher;
 }
 
-export type AppendToListener = (streamName: string, events: Event[]) => void;
+export type AppendToListener = (streamName: string, events: Event[], isRepublishing?: boolean) => void;
 
 export type StreamType = "write-model" | "public";
 

--- a/packages/infrastructure/src/lib/MultiModelStore.ts
+++ b/packages/infrastructure/src/lib/MultiModelStore.ts
@@ -5,7 +5,7 @@ import {Payload} from "@event-engine/messaging/message";
 
 export interface MultiModelStore {
   loadEvents: <P extends Payload = any, M extends EventMeta = any>(streamName: string, metadataMatcher?: MetadataMatcher, fromEventId?: string, limit?: number) => Promise<AsyncIterable<Event<P,M>>>;
-  loadDoc: <D extends object>(collectionName: string, docId: string) => Promise<D | null>;
+  loadDoc: <D extends object>(collectionName: string, docId: string) => Promise<{doc: D, version: number} | null>;
   beginSession: () => Session;
   commitSession: (session: Session) => Promise<boolean>;
 }

--- a/packages/infrastructure/src/lib/MultiModelStore/PostgresMultiModelStore.ts
+++ b/packages/infrastructure/src/lib/MultiModelStore/PostgresMultiModelStore.ts
@@ -78,7 +78,8 @@ export class PostgresMultiModelStore implements MultiModelStore {
     return true;
   }
 
-  loadDoc<D extends object>(collectionName: string, docId: string): Promise<D | null> {
+  loadDoc<D extends object>(collectionName: string, docId: string): Promise<{doc: D, version: number} | null> {
+    // @TODO: getDocAndVersion
     return this.documentStore.getDoc(collectionName, docId);
   }
 

--- a/packages/infrastructure/src/lib/MultiModelStore/Session.ts
+++ b/packages/infrastructure/src/lib/MultiModelStore/Session.ts
@@ -1,5 +1,6 @@
 import {Event} from "@event-engine/messaging/event";
 import {MetadataMatcher} from "@event-engine/infrastructure/EventStore";
+import {Filter} from "@event-engine/infrastructure/DocumentStore/Filter";
 
 interface AppendEventsTask {
   streamName: string;
@@ -17,18 +18,51 @@ interface UpsertDocumentTask {
   collectionName: string;
   docId: string;
   doc: object;
+  metadata?: object;
+  version?: number;
 }
+
+type InsertDocumentTask = UpsertDocumentTask;
+type UpdateDocumentTask = UpsertDocumentTask;
+type ReplaceDocumentTask = UpsertDocumentTask;
 
 interface DeleteDocumentTask {
   collectionName: string;
   docId: string;
 }
 
+interface UpdateManyDocumentsTask {
+  collectionName: string;
+  filter: Filter;
+  docOrSubset: object;
+  metadata?: object;
+  version?: number;
+}
+
+interface ReplaceManyDocumentsTask {
+  collectionName: string;
+  filter: Filter;
+  doc: object;
+  metadata?: object;
+  version?: number;
+}
+
+interface DeleteManyDocumentsTask {
+  collectionName: string;
+  filter: Filter;
+}
+
 export class Session {
   private appendEventsTasks: AppendEventsTask[] = [];
   private deleteEventsTasks: DeleteEventsTask[] = [];
+  private insertDocumentTasks: InsertDocumentTask[] = [];
   private upsertDocumentTasks: UpsertDocumentTask[] = [];
+  private updateDocumentTasks: UpdateDocumentTask[] = [];
+  private replaceDocumentTasks: ReplaceDocumentTask[] = [];
   private deleteDocumentTasks: DeleteDocumentTask[] = [];
+  private updateManyDocumentsTasks: UpdateManyDocumentsTask[] = [];
+  private replaceManyDocumentsTasks: ReplaceManyDocumentsTask[] = [];
+  private deleteManyDocumentsTasks: DeleteManyDocumentsTask[] = [];
   private committed = false;
 
   public appendEventsTo(streamName: string, events: Event[], metadataMatcher?: MetadataMatcher, expectedVersion?: number): void {
@@ -45,11 +79,32 @@ export class Session {
     this.deleteEventsTasks.push({streamName, metadataMatcher});
   }
 
-  public upsertDocument(collectionName: string, docId: string, doc: object): void {
+  public insertDocument(collectionName: string, docId: string, doc: object, metadata?: object, version?: number): void {
+    if(this.committed) {
+      throw new Error(`[DB] Cannot insert document (${docId}) in collection: ${collectionName}. Multi-Model-Store Session is already committed.`)
+    }
+    this.insertDocumentTasks.push({collectionName, docId, doc, metadata, version});
+  }
+
+  public upsertDocument(collectionName: string, docId: string, doc: object, metadata?: object, version?: number): void {
     if(this.committed) {
       throw new Error(`[DB] Cannot upsert document (${docId}) in collection: ${collectionName}. Multi-Model-Store Session is already committed.`)
     }
-    this.upsertDocumentTasks.push({collectionName, docId, doc});
+    this.upsertDocumentTasks.push({collectionName, docId, doc, metadata, version});
+  }
+
+  public updateDocument(collectionName: string, docId: string, docOrSubset: object, metadata?: object, version?: number): void {
+    if(this.committed) {
+      throw new Error(`[DB] Cannot update document (${docId}) in collection: ${collectionName}. Multi-Model-Store Session is already committed.`)
+    }
+    this.updateDocumentTasks.push({collectionName, docId, doc: docOrSubset, metadata, version});
+  }
+
+  public replaceDocument(collectionName: string, docId: string, doc: object, metadata?: object, version?: number): void {
+    if(this.committed) {
+      throw new Error(`[DB] Cannot replace document (${docId}) in collection: ${collectionName}. Multi-Model-Store Session is already committed.`)
+    }
+    this.replaceDocumentTasks.push({collectionName, docId, doc, metadata, version});
   }
 
   public deleteDocument(collectionName: string, docId: string): void {
@@ -57,6 +112,27 @@ export class Session {
       throw new Error(`[DB] Cannot delete document (${docId}) in collection: ${collectionName}. Multi-Model-Store Session is already committed.`)
     }
     this.deleteDocumentTasks.push({collectionName, docId});
+  }
+
+  public updateManyDocuments(collectionName: string, filter: Filter, docOrSubset: object, metadata?: object, version?: number): void {
+    if(this.committed) {
+      throw new Error(`[DB] Cannot update documents in collection: ${collectionName}. Multi-Model-Store Session is already committed.`)
+    }
+    this.updateManyDocumentsTasks.push({collectionName, filter, docOrSubset, metadata, version});
+  }
+
+  public replaceManyDocuments(collectionName: string, filter: Filter, doc: object, metadata?: object, version?: number): void {
+    if(this.committed) {
+      throw new Error(`[DB] Cannot replace documents in collection: ${collectionName}. Multi-Model-Store Session is already committed.`)
+    }
+    this.replaceManyDocumentsTasks.push({collectionName, filter, doc, metadata, version});
+  }
+
+  public deleteManyDocuments(collectionName: string, filter: Filter): void {
+    if(this.committed) {
+      throw new Error(`[DB] Cannot delete documents in collection: ${collectionName}. Multi-Model-Store Session is already committed.`)
+    }
+    this.deleteManyDocumentsTasks.push({collectionName, filter});
   }
 
   public getAppendEventsTasks(): AppendEventsTask[] {
@@ -67,12 +143,36 @@ export class Session {
     return [...this.deleteEventsTasks];
   }
 
+  public getInsertDocumentTasks(): InsertDocumentTask[] {
+    return [...this.insertDocumentTasks];
+  }
+
   public getUpsertDocumentTasks(): UpsertDocumentTask[] {
     return [...this.upsertDocumentTasks];
   }
 
+  public getUpdateDocumentTasks(): UpdateDocumentTask[] {
+    return [...this.updateDocumentTasks];
+  }
+
+  public getReplaceDocumentTasks(): ReplaceDocumentTask[] {
+    return [...this.replaceDocumentTasks];
+  }
+
   public getDeleteDocumentTasks(): DeleteDocumentTask[] {
     return [...this.deleteDocumentTasks];
+  }
+
+  public getUpdateManyDocumentsTasks(): UpdateManyDocumentsTask[] {
+    return [...this.updateManyDocumentsTasks];
+  }
+
+  public getReplaceManyDocumentsTasks(): ReplaceManyDocumentsTask[] {
+    return [...this.replaceManyDocumentsTasks];
+  }
+
+  public getDeleteManyDocumentsTasks(): DeleteManyDocumentsTask[] {
+    return [...this.deleteManyDocumentsTasks];
   }
 
   public commit(): void {

--- a/packages/infrastructure/src/lib/Projection/types.ts
+++ b/packages/infrastructure/src/lib/Projection/types.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_READ_MODEL_PROJECTION = 'read_model';

--- a/packages/messaging/src/lib/command-bus.ts
+++ b/packages/messaging/src/lib/command-bus.ts
@@ -1,0 +1,6 @@
+import {Command} from "@event-engine/messaging/command";
+import {CommandDescription} from "@event-engine/descriptions/descriptions";
+
+export interface CommandBus {
+  dispatch: (command: Command, desc: CommandDescription) => Promise<boolean>;
+}

--- a/packages/messaging/src/lib/event-bus.ts
+++ b/packages/messaging/src/lib/event-bus.ts
@@ -1,0 +1,5 @@
+import {Event} from "@event-engine/messaging/event";
+
+export interface EventBus {
+  on: (event: Event, triggerLiveProjections?: boolean) => Promise<boolean>;
+}

--- a/packages/messaging/src/lib/message-box.ts
+++ b/packages/messaging/src/lib/message-box.ts
@@ -1,0 +1,18 @@
+import {CommandBus} from "@event-engine/messaging/command-bus";
+import {EventBus} from "@event-engine/messaging/event-bus";
+import {QueryBus} from "@event-engine/messaging/query-bus";
+import {CommandRuntimeInfo} from "@event-engine/messaging/command";
+import {EventRuntimeInfo} from "@event-engine/messaging/event";
+import {QueryRuntimeInfo} from "@event-engine/messaging/query";
+
+export interface MessageBox {
+  commandBus: CommandBus;
+  eventBus: EventBus;
+  queryBus: QueryBus;
+  isCommand: (name: string) => boolean;
+  isEvent: (name: string) => boolean
+  isQuery: (name: string) => boolean;
+  getCommandInfo: (name: string) => CommandRuntimeInfo;
+  getEventInfo: (name: string) => EventRuntimeInfo;
+  getQueryInfo: (name: string) => QueryRuntimeInfo
+}

--- a/packages/messaging/src/lib/query-bus.ts
+++ b/packages/messaging/src/lib/query-bus.ts
@@ -1,0 +1,7 @@
+import {Payload} from "@event-engine/messaging/message";
+import {Query} from "@event-engine/messaging/query";
+import {QueryDescription} from "@event-engine/descriptions/descriptions";
+
+export interface QueryBus {
+  dispatch: <S extends Payload = any>(query: Query, desc: QueryDescription) => Promise<S>;
+}

--- a/packages/play/src/infrastructure/commands/make-command-mutation-fn.ts
+++ b/packages/play/src/infrastructure/commands/make-command-mutation-fn.ts
@@ -30,6 +30,10 @@ import {ValidationError} from "ajv";
 import {makeCommandFactory} from "@cody-play/infrastructure/commands/make-command-factory";
 import {playLoadDependencies} from "@cody-play/infrastructure/cody/dependencies/play-load-dependencies";
 import {CodyPlayConfig} from "@cody-play/state/config-store";
+import {
+  playInformationServiceFactory
+} from "@cody-play/infrastructure/infromation-service/play-information-service-factory";
+import {getConfiguredPlayMessageBox} from "@cody-play/infrastructure/message-box/configured-message-box";
 
 export const makeCommandMutationFn = (
   commandInfo: PlayCommandRuntimeInfo,
@@ -64,7 +68,8 @@ export const makeCommandMutationFn = (
     const repository = makeAggregateRepository(
       aggregateDesc,
       eventReducers,
-      stateInfo
+      stateInfo,
+      config
     );
 
     const processingFunction = makeCommandHandler(
@@ -107,7 +112,8 @@ export const makeCommandMutationFn = (
 export const makeAggregateRepository = (
   aggregateDesc: AggregateDescription,
   eventReducers: PlayEventReducers,
-  stateInfo: PlayInformationRuntimeInfo
+  stateInfo: PlayInformationRuntimeInfo,
+  config: CodyPlayConfig
 ): AggregateRepository => {
   return new AggregateRepository<any>(
     getConfiguredPlayMultiModelStore(),
@@ -117,7 +123,9 @@ export const makeAggregateRepository = (
     aggregateDesc.identifier,
     makeEventReducers(eventReducers),
     makeInformationFactory(stateInfo.factory),
-    getConfiguredPlayAuthService()
+    getConfiguredPlayAuthService(),
+    playInformationServiceFactory(),
+    getConfiguredPlayMessageBox(config)
   )
 }
 

--- a/packages/play/src/infrastructure/infromation-service/play-information-service-factory.ts
+++ b/packages/play/src/infrastructure/infromation-service/play-information-service-factory.ts
@@ -1,0 +1,15 @@
+import {InformationService} from "@server/infrastructure/information-service/information-service";
+import {
+  DocumentStoreInformationService
+} from "@server/infrastructure/information-service/document-store-information-service";
+import {getConfiguredPlayDocumentStore} from "@cody-play/infrastructure/multi-model-store/configured-document-store";
+
+let informationService: InformationService;
+
+export const playInformationServiceFactory = (): InformationService => {
+  if(!informationService) {
+    informationService = new DocumentStoreInformationService(getConfiguredPlayDocumentStore());
+  }
+
+  return informationService;
+}

--- a/packages/play/src/infrastructure/message-box/configured-message-box.ts
+++ b/packages/play/src/infrastructure/message-box/configured-message-box.ts
@@ -1,0 +1,15 @@
+import {MessageBox} from "@event-engine/messaging/message-box";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+import {PlayMessageBox} from "@cody-play/infrastructure/message-box/play-message-box";
+
+let messageBox: PlayMessageBox;
+
+export const getConfiguredPlayMessageBox = (config: CodyPlayConfig): PlayMessageBox => {
+  if(!messageBox) {
+    messageBox = new PlayMessageBox(config);
+  } else {
+    messageBox.updateConfig(config);
+  }
+
+  return messageBox;
+}

--- a/packages/play/src/infrastructure/message-box/play-message-box.ts
+++ b/packages/play/src/infrastructure/message-box/play-message-box.ts
@@ -1,0 +1,201 @@
+import {MessageBox} from "@event-engine/messaging/message-box";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+import {CommandBus} from "@event-engine/messaging/command-bus";
+import {EventBus} from "@event-engine/messaging/event-bus";
+import {QueryBus} from "@event-engine/messaging/query-bus";
+import {Command, CommandRuntimeInfo} from "@event-engine/messaging/command";
+import {Event, EventRuntimeInfo} from "@event-engine/messaging/event";
+import {Query, QueryRuntimeInfo} from "@event-engine/messaging/query";
+import {
+  CommandDescription,
+  isAggregateCommandDescription,
+  QueryDescription
+} from "@event-engine/descriptions/descriptions";
+import {Payload, setMessageMetadata} from "@event-engine/messaging/message";
+import {META_KEY_DELETE_HISTORY, META_KEY_DELETE_STATE} from "@event-engine/infrastructure/AggregateRepository";
+import {playLoadDependencies} from "@cody-play/infrastructure/cody/dependencies/play-load-dependencies";
+import {makeAggregateRepository} from "@cody-play/infrastructure/commands/make-command-mutation-fn";
+import {makeCommandHandler} from "@cody-play/infrastructure/commands/make-command-handler";
+import {handle} from "@event-engine/infrastructure/commandHandling";
+import {makeAsyncExecutable} from "@cody-play/infrastructure/rule-engine/make-executable";
+import {PlayEventPolicyDescription, PlayEventPolicyRegistry} from "@cody-play/state/types";
+import {makeLocalApiQuery} from "@cody-play/queries/local-api-query";
+import {User} from "@app/shared/types/core/user/user";
+
+export class PlayMessageBox implements MessageBox {
+  private config: CodyPlayConfig;
+
+  public commandBus: CommandBus;
+  public eventBus: EventBus;
+  public queryBus: QueryBus;
+
+  public constructor(config: CodyPlayConfig) {
+    this.config = config;
+
+    this.commandBus = { dispatch: async (command: Command, desc: CommandDescription): Promise<boolean> => {
+      return await dispatchCommand(command, this.config);
+    }};
+
+    this.eventBus = {
+      on: async (event: Event, triggerLiveProjections?: boolean): Promise<boolean> => {
+        return await dispatchEvent(event, this.config, triggerLiveProjections);
+      }
+    }
+
+    this.queryBus = {
+      dispatch: async <S extends Payload = any>(query: Query, desc: QueryDescription): Promise<S> => {
+        return makeLocalApiQuery(this.config, query.meta.user as User)(query.name, query.payload);
+      }
+    }
+  }
+
+  public updateConfig(config: CodyPlayConfig) {
+    this.config = config;
+  }
+
+  getCommandInfo(name: string): CommandRuntimeInfo {
+    if(!this.isCommand(name)) {
+      throw new Error(`Unknown command "${name}" given. Cannot find a description for it.`);
+    }
+
+    return this.config.commands[name] as unknown as CommandRuntimeInfo;
+  }
+
+  getEventInfo(name: string): EventRuntimeInfo {
+    if(!this.isEvent(name)) {
+      throw new Error(`Unknown event "${name}" given. Cannot find a description for it.`);
+    }
+
+    return this.config.events[name] as unknown as EventRuntimeInfo;
+  }
+
+  getQueryInfo(name: string): QueryRuntimeInfo {
+    if(!this.isQuery(name)) {
+      throw new Error(`Unknown query "${name}" given. Cannot find a description for it.`);
+    }
+
+    return this.config.queries[name] as unknown as QueryRuntimeInfo;
+  }
+
+  isCommand(name: string): boolean {
+    return typeof this.config.commands[name] !== 'undefined';
+  }
+
+  isEvent(name: string): boolean {
+    return typeof this.config.events[name] !== 'undefined';
+  }
+
+  isQuery(name: string): boolean {
+    return typeof this.config.queries[name] !== 'undefined';
+  }
+}
+
+const dispatchEvent = async (event: Event, config: CodyPlayConfig, triggerLiveProjections?: boolean): Promise<boolean> => {
+  console.log(`[EventBus] Going to handle event: ${event.name}`);
+
+  const policies = config.eventPolicies[event.name] || {};
+  const filteredPolicies: {[policyName: string]: PlayEventPolicyDescription} = {};
+
+  for (const policyName in policies) {
+    const desc = policies[policyName];
+
+    if(!!desc.live === !!triggerLiveProjections) {
+      filteredPolicies[policyName] = desc;
+    }
+  }
+
+  const policyNames = Object.keys(filteredPolicies);
+
+  if(policyNames.length === 0) {
+    console.log(`[EventBus] No ${triggerLiveProjections? 'live projections' : 'event policies'} registered for event: ${event.name}`);
+  } else {
+    console.log(`[EventBus] Following ${triggerLiveProjections? 'live projections' : 'event policies'} are registered for event "${event.name}": ${policyNames.join(", ")}`);
+  }
+
+  let allSuccess = true;
+  for (const policy of Object.values(filteredPolicies)) {
+    console.log(`[EventBus] Going to execute policy rules of "${policy.name}"`)
+    try {
+      const dependencies = await playLoadDependencies(event, 'event', policy.dependencies || {}, config);
+
+      const ctx = {event: event.payload, meta: event.meta, ...dependencies, commandRegistry: config.commands, schemaDefinitions: config.definitions};
+      const exe = makeAsyncExecutable(policy.rules);
+      const result = await exe(ctx);
+
+      if(result['commands']) {
+        for (const command of result['commands']) {
+          console.log(`[EventBus] Dispatching command "${command.name}" triggered by policy "${policy.name}"`);
+          await dispatchCommand(command, config);
+        }
+      }
+    } catch (e) {
+      console.error(e);
+      allSuccess = false;
+    }
+  }
+
+  return allSuccess;
+}
+
+const dispatchCommand = async (command: Command, config: CodyPlayConfig): Promise<boolean> => {
+  const commandInfo = config.commands[command.name];
+
+  if(!commandInfo) {
+    throw new Error(`Cannot dispatch command "${command.name}". Command is unknown.`);
+  }
+
+  const rules = config.commandHandlers[command.name];
+
+  if(!rules) {
+    throw new Error(`Cannot handle command "${command.name}". No business rules defined. Please connect the command to an aggregate and define business rules in the Cody Wizard`);
+  }
+
+  const commandDesc = commandInfo.desc;
+
+  if(!isAggregateCommandDescription(commandDesc)) {
+    throw new Error(`Cannot handle command "${command.name}". Please connect the command to an aggregate and define business rules in the Cody Wizard`);
+  }
+
+  const aggregate = config.aggregates[commandDesc.aggregateName];
+
+  if(!aggregate) {
+    throw new Error(`Cannot handle command "${command.name}". Aggregate "${commandDesc.aggregateName}" is unknown.`);
+  }
+
+  const aggregateEventReducers = config.eventReducers[commandDesc.aggregateName];
+
+  if(!aggregateEventReducers) {
+    throw new Error(`Cannot handle command "${command.name}". No event reducers found. Please connect the command to an aggregate with at least one event. Use the Cody Wizard to define reducer rules for events.`);
+  }
+
+  const stateInfo = config.types[aggregate.state];
+
+  if(!stateInfo) {
+    throw new Error(`Cannot handle command "${command.name}". The resulting Information "${aggregate.state}" is unknown. Please run Cody with the corresponding information card to register it.`);
+  }
+
+  if(commandDesc.deleteState) {
+    command = setMessageMetadata(command, META_KEY_DELETE_STATE, true);
+  }
+
+  if(commandDesc.deleteHistory) {
+    command = setMessageMetadata(command, META_KEY_DELETE_HISTORY, true);
+  }
+
+  const dependencies = await playLoadDependencies(command, 'command', commandDesc.dependencies || {}, config);
+
+  const repository = makeAggregateRepository(
+    aggregate,
+    aggregateEventReducers,
+    stateInfo,
+    config
+  );
+
+  const processingFunction = makeCommandHandler(
+    rules,
+    config.events,
+    config.definitions
+  );
+
+  return handle(command, processingFunction, repository, commandDesc.newAggregate, dependencies);
+}

--- a/packages/play/src/infrastructure/multi-model-store/configured-play-read-model-projector.ts
+++ b/packages/play/src/infrastructure/multi-model-store/configured-play-read-model-projector.ts
@@ -1,0 +1,76 @@
+import {EventStore, MetadataMatcher} from "@event-engine/infrastructure/EventStore";
+import {InformationService} from "@server/infrastructure/information-service/information-service";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+import {DEFAULT_READ_MODEL_PROJECTION} from "@event-engine/infrastructure/Projection/types";
+import {Event} from "@event-engine/messaging/event";
+import {PlayEventPolicyDescription} from "@cody-play/state/types";
+import {playLoadDependencies} from "@cody-play/infrastructure/cody/dependencies/play-load-dependencies";
+import {makeAsyncExecutable} from "@cody-play/infrastructure/rule-engine/make-executable";
+import {getConfiguredPlayEventStore} from "@cody-play/infrastructure/multi-model-store/configured-event-store";
+
+class PlayReadModelProjector {
+  private eventStore: EventStore;
+  private config: CodyPlayConfig;
+
+
+  constructor(eventStore: EventStore, config: CodyPlayConfig) {
+    this.eventStore = eventStore;
+    this.config = config;
+  }
+
+  public async run(streamName: string, metadataMatcher?: MetadataMatcher, projectionName?: string, fromEventId?: string, limit?: number): Promise<void> {
+    if(!projectionName) {
+      projectionName = DEFAULT_READ_MODEL_PROJECTION;
+    }
+
+    const events = await this.eventStore.load(streamName, metadataMatcher, fromEventId, limit);
+
+    for await (const event of events) {
+      const policies = this.getEventProjections(event, projectionName);
+
+      if(!policies) {
+        continue;
+      }
+
+      for (const policy of Object.values(policies)) {
+        console.log(`[Projector] Going to execute projection rules of "${projectionName}.${policy.name}"`)
+        try {
+          const dependencies = await playLoadDependencies(event, 'event', policy.dependencies || {}, this.config);
+
+          const ctx = {event: event.payload, meta: event.meta, ...dependencies, commandRegistry: this.config.commands, schemaDefinitions: this.config.definitions};
+          const exe = makeAsyncExecutable(policy.rules);
+          const result = await exe(ctx);
+
+          if(result['commands']) {
+            throw new Error(`Projection "${policy.name}" triggered a command. This is not allowed for a projection. Please check its rules!`)
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    }
+  }
+
+  private getEventProjections(event: Event, projectionName: string): {[policyName: string]: PlayEventPolicyDescription} | null {
+    if(this.config.eventPolicies[event.name]) {
+      const filteredPolicies: {[policyName: string]: PlayEventPolicyDescription} = {};
+
+      for (const policyName in this.config.eventPolicies[event.name]) {
+        const policy = this.config.eventPolicies[event.name][policyName];
+
+        if(policy.projection === projectionName) {
+          filteredPolicies[policyName] = policy;
+        }
+      }
+
+      return filteredPolicies
+    }
+
+    return null;
+  }
+}
+
+export const getConfiguredPlayReadModelProjector = (config: CodyPlayConfig) => {
+  const es = getConfiguredPlayEventStore();
+  return new PlayReadModelProjector(es, config);
+}

--- a/packages/play/src/infrastructure/multi-model-store/make-stream-listener.ts
+++ b/packages/play/src/infrastructure/multi-model-store/make-stream-listener.ts
@@ -1,70 +1,20 @@
 import {InMemoryEventStore} from "@event-engine/infrastructure/EventStore/InMemoryEventStore";
-import {CodyPlayConfig} from "@cody-play/state/config-store";
 import {EventQueue} from "@event-engine/infrastructure/EventQueue";
 import {InMemoryStreamListenerQueue} from "@event-engine/infrastructure/Queue/InMemoryStreamListenerQueue";
-import {isAggregateCommandDescription} from "@event-engine/descriptions/descriptions";
-import {setMessageMetadata} from "@event-engine/messaging/message";
-import {META_KEY_DELETE_HISTORY, META_KEY_DELETE_STATE} from "@event-engine/infrastructure/AggregateRepository";
-import {makeCommandHandler} from "@cody-play/infrastructure/commands/make-command-handler";
-import {makeAggregateRepository} from "@cody-play/infrastructure/commands/make-command-mutation-fn";
-import {handle} from "@event-engine/infrastructure/commandHandling";
-import {Command} from "@event-engine/messaging/command";
-import {makeAsyncExecutable} from "@cody-play/infrastructure/rule-engine/make-executable";
-import {playLoadDependencies} from "@cody-play/infrastructure/cody/dependencies/play-load-dependencies";
+import {MessageBox} from "@event-engine/messaging/message-box";
 
 export class PlayStreamListener {
   private readonly queue: EventQueue;
-  private config: CodyPlayConfig;
+  private readonly messageBox: MessageBox;
 
-  public constructor(es: InMemoryEventStore, stream: string, config: CodyPlayConfig) {
+  public constructor(es: InMemoryEventStore, stream: string, messageBox: MessageBox) {
     this.queue = new InMemoryStreamListenerQueue(es, stream);
+    this.messageBox = messageBox;
 
-    this.config = config;
 
     this.queue.attachConsumer(async (event) => {
-
-      console.log(`[PlayStreamListener] Going to handle event: ${event.name}`);
-
-      const policies = this.config.eventPolicies[event.name] || {};
-
-      const policyNames = Object.keys(policies);
-
-      if(policyNames.length === 0) {
-        console.log(`[PlayStreamListener] No event policies registered for event: ${event.name}`);
-      } else {
-        console.log(`[PlayStreamListener] Following event policies are registered for event "${event.name}": ${policyNames.join(", ")}`);
-      }
-
-      let allSuccess = true;
-      for (const policy of Object.values(policies)) {
-        console.log(`[PlayStreamListener] Going to execute policy rules of "${policy.name}"`)
-        try {
-          const dependencies = await playLoadDependencies(event, 'event', policy.dependencies || {}, config);
-
-          const ctx = {event: event.payload, meta: event.meta, ...dependencies, commandRegistry: config.commands, schemaDefinitions: config.definitions};
-          const exe = makeAsyncExecutable(policy.rules);
-          const result = await exe(ctx);
-
-          console.log("result", result);
-
-          if(result['commands']) {
-            for (const command of result['commands']) {
-              console.log(`[PlayStreamListener] Dispatching command "${command.name}" triggered by policy "${policy.name}"`);
-              await dispatchCommand(command, this.config);
-            }
-          }
-        } catch (e) {
-          console.error(e);
-          allSuccess = false;
-        }
-      }
-
-      return allSuccess;
+      return this.messageBox.eventBus.on(event);
     })
-  }
-
-  public updateConfig(newConfig: CodyPlayConfig): void {
-    this.config = newConfig;
   }
 
   public startProcessing(): void {
@@ -74,70 +24,4 @@ export class PlayStreamListener {
   public stopProcessing(): void {
     this.queue.pause();
   }
-}
-
-export const makeStreamListener = (es: InMemoryEventStore, stream: string, config: CodyPlayConfig): PlayStreamListener => {
-  return new PlayStreamListener(es, stream, config);
-}
-
-const dispatchCommand = async (command: Command, config: CodyPlayConfig): Promise<boolean> => {
-  const commandInfo = config.commands[command.name];
-
-  if(!commandInfo) {
-    throw new Error(`Cannot dispatch command "${command.name}". Command is unknown.`);
-  }
-
-  const rules = config.commandHandlers[command.name];
-
-  if(!rules) {
-    throw new Error(`Cannot handle command "${command.name}". No business rules defined. Please connect the command to an aggregate and define business rules in the Cody Wizard`);
-  }
-
-  const commandDesc = commandInfo.desc;
-
-  if(!isAggregateCommandDescription(commandDesc)) {
-    throw new Error(`Cannot handle command "${command.name}". Please connect the command to an aggregate and define business rules in the Cody Wizard`);
-  }
-
-  const aggregate = config.aggregates[commandDesc.aggregateName];
-
-  if(!aggregate) {
-    throw new Error(`Cannot handle command "${command.name}". Aggregate "${commandDesc.aggregateName}" is unknown.`);
-  }
-
-  const aggregateEventReducers = config.eventReducers[commandDesc.aggregateName];
-
-  if(!aggregateEventReducers) {
-    throw new Error(`Cannot handle command "${command.name}". No event reducers found. Please connect the command to an aggregate with at least one event. Use the Cody Wizard to define reducer rules for events.`);
-  }
-
-  const stateInfo = config.types[aggregate.state];
-
-  if(!stateInfo) {
-    throw new Error(`Cannot handle command "${command.name}". The resulting Information "${aggregate.state}" is unknown. Please run Cody with the corresponding information card to register it.`);
-  }
-
-  if(commandDesc.deleteState) {
-    command = setMessageMetadata(command, META_KEY_DELETE_STATE, true);
-  }
-
-  if(commandDesc.deleteHistory) {
-    command = setMessageMetadata(command, META_KEY_DELETE_HISTORY, true);
-  }
-
-  const dependencies = await playLoadDependencies(command, 'command', commandDesc.dependencies || {}, config);
-
-  const repository = makeAggregateRepository(
-    aggregate,
-    aggregateEventReducers,
-    stateInfo
-  );
-
-  const processingFunction = makeCommandHandler(
-    rules,
-    config.events,
-    config.definitions
-  );
-
-  return handle(command, processingFunction, repository, commandDesc.newAggregate, dependencies);
 }

--- a/packages/play/src/infrastructure/rule-engine/normalize-projection-rules.ts
+++ b/packages/play/src/infrastructure/rule-engine/normalize-projection-rules.ts
@@ -1,0 +1,44 @@
+import {
+  AnyRule, isDeleteInformation,
+  isInsertInformation, isReplaceInformation, isUpdateInformation,
+  isUpsertInformation
+} from "@cody-engine/cody/hooks/utils/rule-engine/configuration";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+import {visitRulesThen} from "@cody-engine/cody/hooks/utils/rule-engine/visit-rule-then";
+import {playGetVoRuntimeInfoFromDataReference} from "@cody-play/state/play-get-vo-runtime-info-from-data-reference";
+
+export const normalizeProjectionRules = (rules: AnyRule[], policyService: string, config: CodyPlayConfig): AnyRule[] => {
+  return visitRulesThen(rules, then => {
+    if(isInsertInformation(then)) {
+      return {
+        insert: {...then.insert, information: playGetVoRuntimeInfoFromDataReference(then.insert.information, policyService, config.types).desc.name}
+      }
+    }
+
+    if(isUpsertInformation(then)) {
+      return {
+        upsert: {...then.upsert, information: playGetVoRuntimeInfoFromDataReference(then.upsert.information, policyService, config.types).desc.name}
+      }
+    }
+
+    if(isUpdateInformation(then)) {
+      return {
+        update: {...then.update, information: playGetVoRuntimeInfoFromDataReference(then.update.information, policyService, config.types).desc.name}
+      }
+    }
+
+    if(isReplaceInformation(then)) {
+      return {
+        replace: {...then.replace, information: playGetVoRuntimeInfoFromDataReference(then.replace.information, policyService, config.types).desc.name}
+      }
+    }
+
+    if(isDeleteInformation(then)) {
+      return {
+        delete: {...then.delete, information: playGetVoRuntimeInfoFromDataReference(then.delete.information, policyService, config.types).desc.name}
+      }
+    }
+
+    return then;
+  })
+}

--- a/packages/play/src/infrastructure/rule-engine/normalize-then-record-event-rules.ts
+++ b/packages/play/src/infrastructure/rule-engine/normalize-then-record-event-rules.ts
@@ -1,39 +1,15 @@
 import {
-  AnyRule, isExecuteRules, isForEach,
-  isIfConditionRule,
-  isIfNotConditionRule, isRecordEvent,
-  ThenType
+  AnyRule, isRecordEvent
 } from "@cody-engine/cody/hooks/utils/rule-engine/configuration";
 import {names} from "@event-engine/messaging/helpers";
+import {visitRulesThen} from "@cody-engine/cody/hooks/utils/rule-engine/visit-rule-then";
 
 export const normalizeThenRecordEventRules = (aggregate: string, rules: AnyRule[]): AnyRule[] => {
-  return rules.map(r => normalizeRule(aggregate, r));
-}
-
-const normalizeRule = (aggregate: string, rule: AnyRule): AnyRule => {
-  const clonedRule = {...rule};
-  if(isIfConditionRule(rule) || isIfNotConditionRule(rule)) {
-    if(rule.else && (isIfConditionRule(clonedRule) || isIfNotConditionRule(clonedRule))) {
-      clonedRule.else = normalizeThen(aggregate, rule.else);
+  return visitRulesThen(rules, then => {
+    if(isRecordEvent(then)) {
+      return {record: {event: aggregate + '.' + names(then.record.event).className, mapping: then.record.mapping}};
     }
-  }
-  clonedRule.then = normalizeThen(aggregate, rule.then);
 
-  return clonedRule;
-}
-
-const normalizeThen = (aggregate: string, then: ThenType): ThenType => {
-  if(isExecuteRules(then)) {
-    return {execute: {rules: normalizeThenRecordEventRules(aggregate, then.execute.rules)}};
-  }
-
-  if(isForEach(then)) {
-    return {forEach: {then: normalizeThen(aggregate, then.forEach.then), variable: then.forEach.variable}};
-  }
-
-  if(isRecordEvent(then)) {
-    return {record: {event: aggregate + '.' + names(then.record.event).className, mapping: then.record.mapping}};
-  }
-
-  return then;
+    return then;
+  })
 }

--- a/packages/play/src/main.tsx
+++ b/packages/play/src/main.tsx
@@ -3,6 +3,10 @@ import * as ReactDOM from 'react-dom/client';
 import App from './app/app';
 import {getConfiguredPlayDocumentStore} from "@cody-play/infrastructure/multi-model-store/configured-document-store";
 import {getConfiguredPlayEventStore} from "@cody-play/infrastructure/multi-model-store/configured-event-store";
+import {
+  getConfiguredPlayReadModelProjector
+} from "@cody-play/infrastructure/multi-model-store/configured-play-read-model-projector";
+import {MetadataMatcher} from "@event-engine/infrastructure/EventStore";
 
 document.title = 'Cody Play';
 
@@ -14,8 +18,13 @@ document.title = 'Cody Play';
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window.$CP = {
-      ds,
-      es
+      documentStore: ds,
+      eventStore: es,
+      projector: {
+        run: (streamName: string, metadataMatcher?: MetadataMatcher, projectionName?: string, fromEventId?: string, limit?: number): Promise<void> => {
+          throw new Error('Cody Play Config is not initialized. Please wait a moment and try again!')
+        }
+      }
     }
 
     // Wait a moment, so that DS and ES can load data from local storage

--- a/packages/play/src/queries/local-api-query.ts
+++ b/packages/play/src/queries/local-api-query.ts
@@ -74,7 +74,7 @@ const resolveStateQuery = async (desc: QueryableStateDescription, factory: AnyRu
     throw new Error(`Cannot resolve query: "${queryInfo.desc.name}". Query property "${desc.identifier}" is missing in query payload. This error can be caused by a wrong mapping. Please check potential metadata configuration.`);
   }
 
-  const doc = await ds.getDoc<{state: any}>(desc.collection, params[desc.identifier]);
+  const doc = await ds.getDoc<any>(desc.collection, params[desc.identifier]);
 
   if(!doc) {
     throw new NotFoundError(`"${desc.name}" with "${desc.identifier}": "${params[desc.identifier]}" not found!`);
@@ -84,7 +84,7 @@ const resolveStateQuery = async (desc: QueryableStateDescription, factory: AnyRu
 
   const exe = makeInformationFactory(factory);
 
-  return exe(doc.state);
+  return exe(doc);
 }
 
 const resolveStateListQuery = async (desc: QueryableStateListDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, params: any, user: User): Promise<Array<any>> => {
@@ -102,9 +102,9 @@ const resolveStateListQuery = async (desc: QueryableStateListDescription, factor
 
   const exe = makeInformationFactory(factory);
 
-  const cursor = await ds.findDocs<{state: any}>(desc.collection, filters, undefined, undefined, orderBy);
+  const cursor = await ds.findDocs<any>(desc.collection, filters, undefined, undefined, orderBy);
 
-  return asyncIteratorToArray(asyncMap(cursor, ([, d]) => exe(d.state)));
+  return asyncIteratorToArray(asyncMap(cursor, ([, d]) => exe(d)));
 }
 
 const resolveSingleValueObjectQuery = async (desc: QueryableValueObjectDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, params: any, user: User): Promise<any> => {
@@ -122,9 +122,9 @@ const resolveSingleValueObjectQuery = async (desc: QueryableValueObjectDescripti
 
   const exe = makeInformationFactory(factory);
 
-  const cursor = await ds.findDocs<{state: any}>(desc.collection, filters, undefined, 1, orderBy);
+  const cursor = await ds.findDocs<any>(desc.collection, filters, undefined, 1, orderBy);
 
-  const result = await asyncIteratorToArray(asyncMap(cursor, ([, d]) => exe(d.state)));
+  const result = await asyncIteratorToArray(asyncMap(cursor, ([, d]) => exe(d)));
 
   if(result.length !== 1) {
     throw new NotFoundError(`"${desc.name}" with "${JSON.stringify(params)}" not found!`);

--- a/packages/play/src/queries/make-filters.ts
+++ b/packages/play/src/queries/make-filters.ts
@@ -102,16 +102,16 @@ export const makeFiltersFromQuerySchema = (schema: JSONSchema7, params: any, use
 
 export const mapOrderByProp = (orderBy: SortOrderItem): SortOrderItem => {
   return {
-    prop: `state.${orderBy.prop}`,
+    prop: `${orderBy.prop}`,
     sort: orderBy.sort
   }
 }
 
 const makeEqFilterFromProperty = (prop: string, params: any): DSFilter => {
-  return new filters.EqFilter(`state.${prop}`, params[prop] || '$codyplay__not_set_value__');
+  return new filters.EqFilter(`${prop}`, params[prop] || '$codyplay__not_set_value__');
 }
 
-const makeFilter = (filter: Filter, ctx: any): DSFilter => {
+export const makeFilter = (filter: Filter, ctx: any): DSFilter => {
   if(isAndFilter(filter)) {
     const mappedFilters = filter.and.map(f => makeFilter(f, ctx));
 
@@ -141,7 +141,7 @@ const makeFilter = (filter: Filter, ctx: any): DSFilter => {
   }
 
   if(isAnyOfFilter(filter)) {
-    return new filters.AnyOfFilter(`state.${filter.anyOf.prop}`, execExpr(filter.anyOf.valueList, ctx));
+    return new filters.AnyOfFilter(`${filter.anyOf.prop}`, execExpr(filter.anyOf.valueList, ctx));
   }
 
   if(isDocIdFilter(filter)) {
@@ -149,35 +149,35 @@ const makeFilter = (filter: Filter, ctx: any): DSFilter => {
   }
 
   if(isEqFilter(filter)) {
-    return new filters.EqFilter(`state.${filter.eq.prop}`, execExpr(filter.eq.value, ctx));
+    return new filters.EqFilter(`${filter.eq.prop}`, execExpr(filter.eq.value, ctx));
   }
 
   if(isExistsFilter(filter)) {
-    return new filters.ExistsFilter(`state.${filter.exists.prop}`);
+    return new filters.ExistsFilter(`${filter.exists.prop}`);
   }
 
   if(isGteFilter(filter)) {
-    return new filters.GteFilter(`state.${filter.gte.prop}`, execExpr(filter.gte.value, ctx));
+    return new filters.GteFilter(`${filter.gte.prop}`, execExpr(filter.gte.value, ctx));
   }
 
   if(isGtFilter(filter)) {
-    return new filters.GtFilter(`state.${filter.gt.prop}`, execExpr(filter.gt.value, ctx));
+    return new filters.GtFilter(`${filter.gt.prop}`, execExpr(filter.gt.value, ctx));
   }
 
   if(isInArrayFilter(filter)) {
-    return new filters.InArrayFilter(`state.${filter.inArray.prop}`, execExpr(filter.inArray.value, ctx));
+    return new filters.InArrayFilter(`${filter.inArray.prop}`, execExpr(filter.inArray.value, ctx));
   }
 
   if(isLikeFilter(filter)) {
-    return new filters.LikeFilter(`state.${filter.like.prop}`, execExpr(filter.like.value, ctx));
+    return new filters.LikeFilter(`${filter.like.prop}`, execExpr(filter.like.value, ctx));
   }
 
   if(isLteFilter(filter)) {
-    return new filters.LteFilter(`state.${filter.lte.prop}`, execExpr(filter.lte.value, ctx));
+    return new filters.LteFilter(`${filter.lte.prop}`, execExpr(filter.lte.value, ctx));
   }
 
   if(isLtFilter(filter)) {
-    return new filters.LtFilter(`state.${filter.lt.prop}`, execExpr(filter.lt.value, ctx));
+    return new filters.LtFilter(`${filter.lt.prop}`, execExpr(filter.lt.value, ctx));
   }
 
   return makeAnyFilter();


### PR DESCRIPTION
This PR adds read model projections to Cody Engine and Cody Play.

The projections can be configured on prooph board using policy cards. The rule engine supports several new rules that can be used in policy rules:

## Insert Information

```json
{
  "rule": "always",
  "then": {
    "insert": {
      "information": "/Ns/InformationName",
      "id": "event.readModelId",
      "set": {
        "property": "event.property"
      }
    }
  }
}
```

## Upsert Information

```json
{
  "rule": "always",
  "then": {
    "upsert": {
      "information": "/Ns/InformationName",
      "id": "event.readModelId",
      "set": {
        "property": "event.property"
      }
    }
  }
}
```

## Update Information

```json
{
  "rule": "always",
  "then": {
    "update": {
      "information": "/Ns/InformationName",
      "filter": {
        "docId": "event.readModelId"
      },
      "set": {
        "property": "event.property"
      }
    }
  }
}
```

## Replace Information

```json
{
  "rule": "always",
  "then": {
    "replace": {
      "information": "/Ns/InformationName",
      "filter": {
        "docId": "event.readModelId"
      },
      "set": {
        "property": "event.property"
      }
    }
  }
}
```

## Delete Information

```json
{
  "rule": "always",
  "then": {
    "delete": {
      "information": "/Ns/InformationName",
      "filter": {
        "docId": "event.readModelId"
      }
    }
  }
}
```

## Live Projections
It's possible to include projections into the unit of work of the write model by setting a `live: true` in the policy metadata. This way the read model gets updated within the same transaction as aggregate state and events. You can switch to async execution at any time by setting `live: false`

## Named Projections
By default, all projection functions (policies on prooph board) are grouped under the name `read_model`. If you set `projection: "my_projection_name"` in policy metadata, all projection functions with the setting are grouped under that name instead.

## Run Projection From CLI
A new CLI command to run a projection is added to Cody Engine. See README for details.

It's also possible to run a projection by hand in Cody Play via browser console:

```js
await $CP.projections.run('stream_name', {$eventId: "..."}, "read_model");
```

## BC Break

**Attention**: I've refactored the storage structure of aggregate state. Before, aggregate state was stored like this:

### Document Structure of Aggregate State
```json
{
  "state": {...},
  "version": 1
}
```

I've changed the document store interface and column structure so that every document has a top level version property.
The `AggregateRepository` no longer works with the nested state and version properties, but instead leverages the top level properties.
The document store will automatically add and update a version for read models, as long as no version is explicitly passed to the document store functions.

The InMemoryDocumentStore converts the old structure into the new structure while importing documents from the filesystem or Cody Play local storage.

However, you have to regenerate a couple of files with Cody when using the Cody Engine:

- all aggregate repositories, because it needs new services to be injected
- all query resolvers, because `state` no longer exists

This change was necessary to align aggregate state and read model structure in the documents. This differs now from Event Engine, that uses `state` and `version` properties inside the document.

Cody Engine allows citizen developers to use the rule engine in prooph board to develop logic like filters for queries, read model updates, etc. They should not be required to alway pay attention if they deal with aggregate state or  a read model. The unified structure makes it possible. 

### CodyInformationService
A new standard service needs to be added to `packages/be/src/extensions/services.ts`. 

Check the corresponding template `packages/be/src/extensions/services.ts.cetmpl` 