### PR TITLE
feat(resolver rules): Allow additional rules in query resolver

### DIFF
--- a/packages/be/src/infrastructure/information-service/document-store-information-service.ts
+++ b/packages/be/src/infrastructure/information-service/document-store-information-service.ts
@@ -1,5 +1,5 @@
 import {InformationService} from "@server/infrastructure/information-service/information-service";
-import {DocumentStore} from "@event-engine/infrastructure/DocumentStore";
+import {DocumentStore, SortOrder} from "@event-engine/infrastructure/DocumentStore";
 import {types} from "@app/shared/types";
 import {
   isQueryableStateDescription,
@@ -8,6 +8,9 @@ import {
 } from "@event-engine/descriptions/descriptions";
 import {Session} from "@event-engine/infrastructure/MultiModelStore/Session";
 import {Filter} from "@event-engine/infrastructure/DocumentStore/Filter";
+import {asyncIteratorToArray} from "@event-engine/infrastructure/helpers/async-iterator-to-array";
+import {asyncMap} from "@event-engine/infrastructure/helpers/async-map";
+import {makeValueObject, ValueObjectRuntimeInfo} from "@event-engine/messaging/value-object";
 
 export class DocumentStoreInformationService implements InformationService {
   private ds: DocumentStore;
@@ -23,6 +26,20 @@ export class DocumentStoreInformationService implements InformationService {
 
   public forgetSession(): void {
     this.session = undefined;
+  }
+
+  public async find<T extends object>(informationName: string, filter: Filter, skip?: number, limit?: number, orderBy?: SortOrder): Promise<Array<T>> {
+    const collectionName = this.detectCollection(informationName);
+
+    const cursor = await this.ds.findDocs<T>(collectionName, filter, skip, limit, orderBy);
+
+    return asyncIteratorToArray(asyncMap(cursor, ([,doc]) => doc));
+  }
+
+  public async count(informationName: string, filter: Filter): Promise<number> {
+    const collectionName = this.detectCollection(informationName);
+
+    return this.ds.countDocs(collectionName, filter);
   }
 
   public async insert(informationName: string, id: string, data: object, metadata?: object, version?: number): Promise<void> {
@@ -76,11 +93,7 @@ export class DocumentStoreInformationService implements InformationService {
   }
 
   private detectCollection(informationName: string): string {
-    const runtimeInfo = types[informationName];
-
-    if(!runtimeInfo) {
-      throw new Error(`Can't find the type: '${informationName}' in the type registry. Did you forget to pass the corresponding information card on prooph board to Cody?`);
-    }
+    const runtimeInfo = this.detectSingleVoRuntimeInfo(informationName);
 
     const desc = runtimeInfo.desc;
 
@@ -89,5 +102,23 @@ export class DocumentStoreInformationService implements InformationService {
     }
 
     return desc.collection;
+  }
+
+  private detectSingleVoRuntimeInfo(informationName: string): ValueObjectRuntimeInfo {
+    const runtimeInfo = types[informationName];
+
+    if(!runtimeInfo) {
+      throw new Error(`Can't find the type: '${informationName}' in the type registry. Did you forget to pass the corresponding information card on prooph board to Cody?`);
+    }
+
+    if(isQueryableStateListDescription(runtimeInfo.desc)) {
+      return this.detectSingleVoRuntimeInfo(runtimeInfo.desc.itemType);
+    }
+
+    if(isQueryableStateDescription(runtimeInfo.desc) || isQueryableValueObjectDescription(runtimeInfo.desc)) {
+      return runtimeInfo;
+    }
+
+    throw new Error(`Information "${informationName}" is neither a queryable list nor queryable information. Please check your prooph board metadata configuration of the information card`);
   }
 }

--- a/packages/be/src/infrastructure/information-service/information-service.ts
+++ b/packages/be/src/infrastructure/information-service/information-service.ts
@@ -1,11 +1,14 @@
 import {Filter} from "@event-engine/infrastructure/DocumentStore/Filter";
 import {Session} from "@event-engine/infrastructure/MultiModelStore/Session";
+import {SortOrder} from "@event-engine/infrastructure/DocumentStore";
 
 export const INFORMATION_SERVICE_NAME = 'CodyInformationService';
 
 export interface InformationService {
   useSession: (session: Session) => void;
   forgetSession: () => void;
+  find: <T extends object>(informationName: string, filter: Filter, skip?: number, limit?: number, orderBy?: SortOrder) => Promise<Array<T>>;
+  count: (informationName: string, filter: Filter) => Promise<number>;
   insert: (informationName: string, id: string, data: object, metadata?: object, version?: number) => Promise<void>;
   upsert: (informationName: string, id: string, data: object, metadata?: object, version?: number) => Promise<void>;
   update: (informationName: string, filter: Filter, data: object, metadata?: object, version?: number) => Promise<void>;

--- a/packages/cody/src/lib/hooks/on-document.ts
+++ b/packages/cody/src/lib/hooks/on-document.ts
@@ -35,8 +35,6 @@ export const onDocument: CodyHook<Context> = async (vo: Node, ctx: Context) => {
     const serviceNames = names(service);
     let queryNames;
 
-    console.log(voMeta);
-
     if(voMeta.isQueryable) {
       queryNames = names('Get' + voNames.className);
     }

--- a/packages/cody/src/lib/hooks/on-document.ts
+++ b/packages/cody/src/lib/hooks/on-document.ts
@@ -11,7 +11,7 @@ import {
 } from "./utils/value-object/namespace";
 import {voPath} from "./utils/value-object/vo-path";
 import {
-  detectDescriptionType,
+  detectDescriptionType, isQueryableListDescription, isQueryableNotStoredStateDescription,
   isQueryableStateListDescription,
   isQueryableValueObjectDescription
 } from "@event-engine/descriptions/descriptions";
@@ -34,6 +34,8 @@ export const onDocument: CodyHook<Context> = async (vo: Node, ctx: Context) => {
     const service = withErrorCheck(detectService, [vo, ctx]);
     const serviceNames = names(service);
     let queryNames;
+
+    console.log(voMeta);
 
     if(voMeta.isQueryable) {
       queryNames = names('Get' + voNames.className);
@@ -91,11 +93,11 @@ export const onDocument: CodyHook<Context> = async (vo: Node, ctx: Context) => {
 
       let itemNames, itemNS, isList = false, isSingleVOQuery = false;
 
-      if(isQueryableStateListDescription(voMeta)) {
+      if(isQueryableStateListDescription(voMeta) || isQueryableListDescription(voMeta)) {
         itemNames = names(voClassNameFromFQCN(voMeta.itemType));
         itemNS = namespaceNames(valueObjectNamespaceFromFQCN(voMeta.itemType));
         isList = true;
-      } else if (isQueryableValueObjectDescription(voMeta)) {
+      } else if (isQueryableValueObjectDescription(voMeta) || isQueryableNotStoredStateDescription(voMeta)) {
         isSingleVOQuery = true;
       }
 

--- a/packages/cody/src/lib/hooks/on-ui.ts
+++ b/packages/cody/src/lib/hooks/on-ui.ts
@@ -5,7 +5,11 @@ import {asyncWithErrorCheck, CodyResponseException, withErrorCheck} from "./util
 import {getUiMetadata} from "./utils/ui/get-ui-metadata";
 import {getNodeFromSyncedNodes} from "./utils/node-tree";
 import {getVoMetadata} from "./utils/value-object/get-vo-metadata";
-import {isQueryableStateDescription, isQueryableStateListDescription} from "@event-engine/descriptions/descriptions";
+import {
+  isQueryableListDescription, isQueryableNotStoredStateDescription,
+  isQueryableStateDescription,
+  isQueryableStateListDescription
+} from "@event-engine/descriptions/descriptions";
 import {isTopLevelPage} from "./utils/ui/is-top-level-page";
 import {detectRoute} from "./utils/ui/detect-route";
 import {loadPageDefinition} from "./utils/ui/load-page-definition";
@@ -31,7 +35,7 @@ export const onUi: CodyHook<Context> = async (ui, ctx) => {
       const syncedVm = withErrorCheck(getNodeFromSyncedNodes, [vM, ctx.syncedNodes]);
       const vMMeta = withErrorCheck(getVoMetadata, [syncedVm, ctx]);
 
-      if(isQueryableStateDescription(vMMeta)) {
+      if(isQueryableStateDescription(vMMeta) || isQueryableNotStoredStateDescription(vMMeta)) {
         if(!routeParams.includes(vMMeta.identifier)) {
           routeParams.push(vMMeta.identifier);
         }
@@ -77,11 +81,11 @@ export const onUi: CodyHook<Context> = async (ui, ctx) => {
     for (const viewModel of viewModels) {
       const viewModelMeta = withErrorCheck(getVoMetadata, [viewModel, ctx]);
 
-      if(isQueryableStateListDescription(viewModelMeta)) {
+      if(isQueryableStateListDescription(viewModelMeta) || isQueryableListDescription(viewModelMeta)) {
         await asyncWithErrorCheck(upsertListViewComponent, [viewModel, viewModelMeta, ctx, tree]);
       }
 
-      if(isQueryableStateDescription(viewModelMeta)) {
+      if(isQueryableStateDescription(viewModelMeta) || isQueryableNotStoredStateDescription(viewModelMeta)) {
         await asyncWithErrorCheck(upsertStateViewComponent, [viewModel, viewModelMeta, ctx, tree]);
       }
     }

--- a/packages/cody/src/lib/hooks/query-files/be/query-resolvers/__service__/resolve-__fileName__.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/query-files/be/query-resolvers/__service__/resolve-__fileName__.ts__tmpl__
@@ -4,6 +4,11 @@ import jexl from "@app/shared/jexl/get-configured-jexl";
 import {<%= className %>} from "@app/shared/queries/<%= serviceNames.fileName %>/<%= fileName %>";
 import {<%= voNames.propertyName %>, <%= voNames.className %>} from "@app/shared/types/<%= serviceNames.fileName %><%= ns.fileName %><%= voNames.fileName %>";
 import {<%= voNames.className %>Desc} from "@app/shared/types/<%= serviceNames.fileName %><%= ns.fileName %><%= voNames.fileName %>.desc";
+import {
+  INFORMATION_SERVICE_NAME,
+  InformationService
+} from "@server/infrastructure/information-service/information-service";
+import {getExternalServiceOrThrow} from "@server/extensions/get-external-service";
 <% if (!isList) { %>import {NotFoundError} from "@event-engine/messaging/error/not-found-error";<% } %>
 <% if (isList) { %>import {<%= itemNames.propertyName %>, <%= itemNames.className %>} from "@app/shared/types/<%= serviceNames.fileName %><%= itemNS.fileName %><%= itemNames.fileName %>";<% } %>
 <% if (isList || isSingleVOQuery) { %>import {filters} from "@event-engine/infrastructure/DocumentStore/Filter/index";<% } %>
@@ -12,6 +17,7 @@ import {<%= voNames.className %>Desc} from "@app/shared/types/<%= serviceNames.f
 
 export const resolve<%= className %> = async (query: Query<<%= className %>>): Promise<<%= voNames.className %>> => {
   const ds = getConfiguredDocumentStore();
+  <% if (isList || isSingleVOQuery) { %>const infoService = getExternalServiceOrThrow<InformationService>(INFORMATION_SERVICE_NAME, {});<% } %>
 
   <%- resolve %>
 }

--- a/packages/cody/src/lib/hooks/ui-files/list-view-files/app/components/__service__/views/__className__.tsx__tmpl__
+++ b/packages/cody/src/lib/hooks/ui-files/list-view-files/app/components/__service__/views/__className__.tsx__tmpl__
@@ -26,7 +26,7 @@ const <%= className %> = (params: Get<%= className %>) => {
       {query.isSuccess && <DataGrid
           columns={columns}
           rows={query.data}
-          getRowId={row => row.<%= identifier %>}
+          getRowId={row => <% if (identifier) { %>row.<%= identifier %> <% } else { %>JSON.stringify(row) <% } %>}
           sx={{width: "100%"}}
           slots={{
             <% if (!hideToolbar) { %>toolbar: GridToolbar,<% } %>

--- a/packages/cody/src/lib/hooks/utils/json-schema/is-scalar-schema.ts
+++ b/packages/cody/src/lib/hooks/utils/json-schema/is-scalar-schema.ts
@@ -1,0 +1,12 @@
+import {JSONSchema7} from "json-schema-to-ts";
+
+export interface ScalarSchema {
+  type: "string" | "number" | "boolean" | "integer",
+  title?: "string"
+}
+
+const scalarTypes = ["string", "number", "boolean", "integer"];
+
+export const isScalarSchema = (schema: any): schema is ScalarSchema => {
+  return schema['type'] && scalarTypes.includes(schema['type']);
+}

--- a/packages/cody/src/lib/hooks/utils/query/map-order-by.ts
+++ b/packages/cody/src/lib/hooks/utils/query/map-order-by.ts
@@ -1,0 +1,24 @@
+import {SortOrder, SortOrderItem} from "@event-engine/infrastructure/DocumentStore";
+
+export const mapOrderBy = (orderBy: string | SortOrderItem | SortOrder ): SortOrder => {
+  if(Array.isArray(orderBy)) {
+    return orderBy.map(item => mapOrderByProp(item))
+  }
+
+  return [mapOrderByProp(orderBy)];
+}
+
+export const mapOrderByProp = (orderBy: SortOrderItem | string): SortOrderItem => {
+
+  if(typeof orderBy === "string") {
+    return {
+      prop: `${orderBy}`,
+      sort: 'asc'
+    }
+  }
+
+  return {
+    prop: `${orderBy.prop}`,
+    sort: orderBy.sort
+  }
+}

--- a/packages/cody/src/lib/hooks/utils/rule-engine/configuration.ts
+++ b/packages/cody/src/lib/hooks/utils/rule-engine/configuration.ts
@@ -1,4 +1,5 @@
 import {Filter} from "../value-object/query/filter-types";
+import {SortOrder} from "@event-engine/infrastructure/DocumentStore";
 
 export type RuleType = 'always' | 'condition';
 
@@ -33,16 +34,14 @@ export const isIfNotConditionRule = (rule: any): rule is IfNotConditionRule => {
   return typeof rule.if_not !== "undefined";
 }
 
-export type ThenType = ThenRecordEvent | ThenThrowError | ThenAssignVariable | ThenTriggerCommand | ThenCallService | ThenFetchData | ThenExecuteRules | ThenForEach
-  | ThenFilter | ThenInsertInformation | ThenUpsertInformation | ThenUpdateInformation | ThenReplaceInformation | ThenDeleteInformation;
+export type ThenType = ThenRecordEvent | ThenThrowError | ThenAssignVariable | ThenTriggerCommand | ThenCallService | ThenExecuteRules | ThenForEach
+  | ThenFilter | ThenFindInformation | ThenCountInformation | ThenInsertInformation | ThenUpsertInformation | ThenUpdateInformation | ThenReplaceInformation | ThenDeleteInformation;
 
 export type PropMapping = {[name: string]: string | string[]};
 
 export interface ThenFilter {
   filter: Filter;
 }
-
-export const isFilter = (then: any): then is ThenFilter => typeof then.filter !== "undefined";
 
 export interface ThenForEach {
   forEach: {
@@ -104,18 +103,30 @@ export interface ThenCallService {
 
 export const isCallService = (then: any): then is ThenCallService => typeof then.call !== 'undefined';
 
-export interface ThenFetchData {
-  fetch: {
-    query: string;
-    mapping?: string | PropMapping;
-    result: {
-      variable: string;
-      mapping?: string | PropMapping;
-    }
+export const isFilter = (then: any): then is ThenFilter => typeof then.filter !== "undefined";
+
+export interface ThenFindInformation {
+  find: {
+    information: string;
+    filter: Filter;
+    skip?: number;
+    limit?: number;
+    orderBy?: SortOrder;
+    variable?: string;
   }
 }
 
-export const isFetchData = (then: any): then is ThenFetchData => typeof then.fetch !== 'undefined';
+export const isFindInformation = (then: any): then is ThenFindInformation => typeof then.find !== "undefined";
+
+export interface ThenCountInformation {
+  count: {
+    information: string;
+    filter: Filter;
+    variable?: string;
+  }
+}
+
+export const isCountInformation = (then: any): then is ThenCountInformation => typeof then.count !== "undefined";
 
 export interface ThenInsertInformation {
   insert: {

--- a/packages/cody/src/lib/hooks/utils/rule-engine/validate-resolver-rules.ts
+++ b/packages/cody/src/lib/hooks/utils/rule-engine/validate-resolver-rules.ts
@@ -1,0 +1,23 @@
+import {
+  isAssignVariable,
+  isCountInformation, isExecuteRules,
+  isFindInformation, isForEach, isThrowError,
+  Rule
+} from "@cody-engine/cody/hooks/utils/rule-engine/configuration";
+import {visitRulesThen} from "@cody-engine/cody/hooks/utils/rule-engine/visit-rule-then";
+
+export const validateResolverRules = (rules: Rule[]): void => {
+  visitRulesThen(rules, then => {
+    switch (true) {
+      case isFindInformation(then):
+      case isCountInformation(then):
+      case isAssignVariable(then):
+      case isForEach(then):
+      case isExecuteRules(then):
+      case isThrowError(then):
+        return then;
+      default:
+        throw new Error(`Rule ${JSON.stringify(then)} is not allowed in a query resolver`);
+    }
+  });
+}

--- a/packages/cody/src/lib/hooks/utils/ui/is-top-level-page.ts
+++ b/packages/cody/src/lib/hooks/utils/ui/is-top-level-page.ts
@@ -3,7 +3,10 @@ import {Context} from "../../context";
 import {getSourcesOfType, isCodyError} from "@proophboard/cody-utils";
 import {getNodeFromSyncedNodes} from "../node-tree";
 import {getVoMetadata} from "../value-object/get-vo-metadata";
-import {isQueryableStateDescription} from "@event-engine/descriptions/descriptions";
+import {
+  isQueryableNotStoredStateDescription,
+  isQueryableStateDescription
+} from "@event-engine/descriptions/descriptions";
 import {UiMetadata} from "@cody-engine/cody/hooks/utils/ui/types";
 
 export const isTopLevelPage = (ui: Node, uiMeta: UiMetadata, ctx: Context): boolean | CodyResponse => {
@@ -36,7 +39,7 @@ export const isTopLevelPage = (ui: Node, uiMeta: UiMetadata, ctx: Context): bool
       return false;
     }
 
-    if(isQueryableStateDescription(vMMeta)) {
+    if(isQueryableStateDescription(vMMeta) || isQueryableNotStoredStateDescription(vMMeta)) {
       isTopLevelPage = false;
     }
   })

--- a/packages/cody/src/lib/hooks/utils/ui/upsert-page-definition.ts
+++ b/packages/cody/src/lib/hooks/utils/ui/upsert-page-definition.ts
@@ -10,7 +10,11 @@ import {getSourcesOfType, isCodyError} from "@proophboard/cody-utils";
 import {generateFiles} from "@nx/devkit";
 import {toJSON} from "../to-json";
 import {getVoMetadata} from "../value-object/get-vo-metadata";
-import {isQueryableStateDescription, isQueryableStateListDescription} from "@event-engine/descriptions/descriptions";
+import {
+  isQueryableListDescription, isQueryableNotStoredStateDescription,
+  isQueryableStateDescription,
+  isQueryableStateListDescription
+} from "@event-engine/descriptions/descriptions";
 import {convertRuleConfigToDynamicBreadcrumbValueGetterRules} from "../rule-engine/convert-rule-config-to-behavior";
 import {getNodesOfTypeNearby} from "../node-tree";
 import {getVOFromDataReference} from "../value-object/get-vo-from-data-reference";
@@ -216,7 +220,7 @@ const getComponentNames = (viewModels: List<Node>, ctx: Context, existingPageDef
       return service;
     }
 
-    if(isQueryableStateDescription(voMeta) || isQueryableStateListDescription(voMeta)) {
+    if(isQueryableStateDescription(voMeta) || isQueryableNotStoredStateDescription(voMeta) || isQueryableStateListDescription(voMeta) || isQueryableListDescription(voMeta)) {
       const componentName = `${names(service).className}.${names(vo.getName()).className}`;
       if(!componentNames.includes(componentName)) {
         componentNames.push(componentName);

--- a/packages/cody/src/lib/hooks/utils/value-object/types.ts
+++ b/packages/cody/src/lib/hooks/utils/value-object/types.ts
@@ -11,14 +11,15 @@ export interface ValueObjectMetadataRaw {
   querySchema?: any;
   resolve?: ResolveConfig;
   ns?: string;
-  collection?: string;
+  collection?: string | boolean;
   initialize?: Rule[];
   uiSchema?: UiSchema & TableUiSchema;
 }
 
 export interface ResolveConfig {
   where?: Rule,
-  orderBy?: SortOrderItem | SortOrder
+  orderBy?: SortOrderItem | SortOrder,
+  rules?: Rule[],
 }
 
 export interface RefTableColumn {

--- a/packages/cody/src/lib/hooks/vo-files/shared/types/__fileName__.desc.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/vo-files/shared/types/__fileName__.desc.ts__tmpl__
@@ -7,9 +7,9 @@ export const <%= className %>Desc: <%= descriptionType %> = {
   isQueryable: <%= meta.isQueryable %>,
 <% if (meta.hasIdentifier && !meta.isList) {%>  identifier: "<%= meta.identifier %>",<% } %>
 <% if (meta.hasIdentifier && meta.isList) {%>  itemIdentifier: "<%= meta.identifier %>",<% } %>
-<% if (meta.hasIdentifier && meta.isList) {%>  itemType: "<%= meta.itemType %>",<% } %>
+<% if (meta.isList) {%>  itemType: "<%= meta.itemType %>",<% } %>
 <% if (meta.isQueryable) {%>  query: "<%= serviceNames.className %>.<%= queryNames.className %>",<% } %>
-<% if (meta.isQueryable) {%>  collection: "<%= meta.collection %>",<% } %>
+<% if (meta.collection) {%>  collection: "<%= meta.collection %>",<% } %>
   _pbBoardId: "<%= _pbBoardId %>",
   _pbCardId: "<%= _pbCardId %>",
   _pbCreatedBy: "<%= _pbCreatedBy %>",

--- a/packages/descriptions/src/lib/descriptions.ts
+++ b/packages/descriptions/src/lib/descriptions.ts
@@ -74,6 +74,7 @@ export interface ValueObjectDescriptionFlags {
   isList: boolean;
   hasIdentifier: boolean;
   isQueryable: boolean;
+  isNotStored?: boolean;
 }
 
 export interface ValueObjectDescription extends ProophBoardDescription, ValueObjectDescriptionFlags {
@@ -114,6 +115,14 @@ export const isQueryableStateDescription = (desc: ValueObjectDescriptionFlags): 
   return isStateDescription(desc) && desc.isQueryable;
 }
 
+export interface QueryableNotStoredStateDescription extends StateDescription {
+  query: string;
+}
+
+export const isQueryableNotStoredStateDescription = (desc: ValueObjectDescriptionFlags): desc is QueryableNotStoredStateDescription => {
+  return isStateDescription(desc) && desc.isQueryable && !!desc.isNotStored;
+}
+
 export interface QueryableStateListDescription extends StateListDescription {
   query: string;
   collection: string;
@@ -124,12 +133,25 @@ export const isQueryableStateListDescription = (desc: ValueObjectDescriptionFlag
   return isStateListDescription(desc) && desc.isQueryable;
 }
 
-export type ValueObjectDescriptionType = "ValueObjectDescription" | "StateDescription" | "StateListDescription" | "QueryableValueObjectDescription" | "QueryableStateDescription" | "QueryableStateListDescription";
+export interface QueryableListDescription extends ValueObjectDescription {
+  query: string;
+  itemType: string;
+}
+
+export const isQueryableListDescription = (desc: ValueObjectDescriptionFlags): desc is QueryableListDescription => {
+  return desc.isList && !desc.hasIdentifier && desc.isQueryable;
+}
+
+export type ValueObjectDescriptionType = "ValueObjectDescription" | "StateDescription" | "StateListDescription" | "QueryableValueObjectDescription" | "QueryableStateDescription" | "QueryableNotStoredStateDescription" | "QueryableStateListDescription" | "QueryableListDescription";
 
 export const detectDescriptionType = (desc: ValueObjectDescriptionFlags): ValueObjectDescriptionType => {
   switch (true) {
     case isQueryableStateListDescription(desc):
       return "QueryableStateListDescription";
+    case isQueryableListDescription(desc):
+      return "QueryableListDescription";
+    case isQueryableNotStoredStateDescription(desc):
+      return "QueryableNotStoredStateDescription";
     case isQueryableStateDescription(desc):
       return "QueryableStateDescription";
     case isStateListDescription(desc):

--- a/packages/infrastructure/src/lib/AggregateRepository.ts
+++ b/packages/infrastructure/src/lib/AggregateRepository.ts
@@ -184,8 +184,6 @@ export class AggregateRepository<T extends object = any> {
             session.appendEventsTo(this.publicStream, publicEvents);
         }
 
-        console.log("before live projections");
-
         // Trigger live projections
         this.infoService.useSession(session);
         try {
@@ -196,7 +194,6 @@ export class AggregateRepository<T extends object = any> {
             return await this.store.commitSession(session);
         } catch (e) {
             this.infoService.forgetSession();
-            console.log("exception caught before store commit", e);
             throw e;
         }
     }

--- a/packages/infrastructure/src/lib/MultiModelStore/InMemoryMultiModelStore.ts
+++ b/packages/infrastructure/src/lib/MultiModelStore/InMemoryMultiModelStore.ts
@@ -28,7 +28,6 @@ export class InMemoryMultiModelStore implements MultiModelStore {
   }
 
   async commitSession(session: Session): Promise<boolean> {
-    console.log("commit session");
     session.commit();
 
     const currentStreams = await this.eventStore.exportStreams();

--- a/packages/play/src/app/pages/play-standard-page.tsx
+++ b/packages/play/src/app/pages/play-standard-page.tsx
@@ -5,7 +5,7 @@ import React, {useContext} from "react";
 import {configStore} from "@cody-play/state/config-store";
 import PlayCommand from "@cody-play/app/components/core/PlayCommand";
 import {PlayInformationRegistry} from "@cody-play/state/types";
-import {isQueryableStateListDescription} from "@event-engine/descriptions/descriptions";
+import {isQueryableListDescription, isQueryableStateListDescription} from "@event-engine/descriptions/descriptions";
 import PlayTableView from "@cody-play/app/components/core/PlayTableView";
 import PlayStateView from "@cody-play/app/components/core/PlayStateView";
 
@@ -49,7 +49,7 @@ const getViewComponent = (component: React.FunctionComponent | { information: st
       throw new Error(`Cannot find view information "${component.information}". Did you forget to run Cody for information card?`)
     }
 
-    if(isQueryableStateListDescription(information.desc)) {
+    if(isQueryableStateListDescription(information.desc) || isQueryableListDescription(information.desc)) {
       return (params: any) => {
         return PlayTableView(params, information);
       };

--- a/packages/play/src/infrastructure/cody/hooks/on-ui.ts
+++ b/packages/play/src/infrastructure/cody/hooks/on-ui.ts
@@ -10,7 +10,10 @@ import {playService} from "@cody-play/infrastructure/cody/service/play-service";
 import {names} from "@event-engine/messaging/helpers";
 import {playIsTopLevelPage} from "@cody-play/infrastructure/cody/ui/play-is-top-level-page";
 import {CodyPlayConfig} from "@cody-play/state/config-store";
-import {isQueryableStateDescription} from "@event-engine/descriptions/descriptions";
+import {
+  isQueryableNotStoredStateDescription,
+  isQueryableStateDescription
+} from "@event-engine/descriptions/descriptions";
 import {
   playGetNodeFromSyncedNodes,
   playGetSourcesOfType, playGetTargetsOfType
@@ -36,7 +39,7 @@ export const onUi = async (ui: Node, dispatch: PlayConfigDispatch, ctx: ElementE
       const syncedVm = playwithErrorCheck(playGetNodeFromSyncedNodes, [vM, ctx.syncedNodes]);
       const vMMeta = playwithErrorCheck(playVoMetadata, [syncedVm, ctx, config.types]);
 
-      if(isQueryableStateDescription(vMMeta)) {
+      if(isQueryableStateDescription(vMMeta) || isQueryableNotStoredStateDescription(vMMeta)) {
         if(!routeParams.includes(vMMeta.identifier)) {
           routeParams.push(vMMeta.identifier);
         }

--- a/packages/play/src/infrastructure/rule-engine/normalize-projection-rules.ts
+++ b/packages/play/src/infrastructure/rule-engine/normalize-projection-rules.ts
@@ -1,5 +1,5 @@
 import {
-  AnyRule, isDeleteInformation,
+  AnyRule, isCountInformation, isDeleteInformation, isFindInformation,
   isInsertInformation, isReplaceInformation, isUpdateInformation,
   isUpsertInformation
 } from "@cody-engine/cody/hooks/utils/rule-engine/configuration";
@@ -7,35 +7,53 @@ import {CodyPlayConfig} from "@cody-play/state/config-store";
 import {visitRulesThen} from "@cody-engine/cody/hooks/utils/rule-engine/visit-rule-then";
 import {playGetVoRuntimeInfoFromDataReference} from "@cody-play/state/play-get-vo-runtime-info-from-data-reference";
 
-export const normalizeProjectionRules = (rules: AnyRule[], policyService: string, config: CodyPlayConfig): AnyRule[] => {
+export const normalizeProjectionRules = (rules: AnyRule[], service: string, config: CodyPlayConfig): AnyRule[] => {
   return visitRulesThen(rules, then => {
+    if(isFindInformation(then)) {
+      return {
+        find: {
+          ...then.find,
+          information: playGetVoRuntimeInfoFromDataReference(then.find.information, service, config.types).desc.name
+        }
+      }
+    }
+
+    if(isCountInformation(then)) {
+      return {
+        count: {
+          ...then.count,
+          information: playGetVoRuntimeInfoFromDataReference(then.count.information, service, config.types).desc.name
+        }
+      }
+    }
+
     if(isInsertInformation(then)) {
       return {
-        insert: {...then.insert, information: playGetVoRuntimeInfoFromDataReference(then.insert.information, policyService, config.types).desc.name}
+        insert: {...then.insert, information: playGetVoRuntimeInfoFromDataReference(then.insert.information, service, config.types).desc.name}
       }
     }
 
     if(isUpsertInformation(then)) {
       return {
-        upsert: {...then.upsert, information: playGetVoRuntimeInfoFromDataReference(then.upsert.information, policyService, config.types).desc.name}
+        upsert: {...then.upsert, information: playGetVoRuntimeInfoFromDataReference(then.upsert.information, service, config.types).desc.name}
       }
     }
 
     if(isUpdateInformation(then)) {
       return {
-        update: {...then.update, information: playGetVoRuntimeInfoFromDataReference(then.update.information, policyService, config.types).desc.name}
+        update: {...then.update, information: playGetVoRuntimeInfoFromDataReference(then.update.information, service, config.types).desc.name}
       }
     }
 
     if(isReplaceInformation(then)) {
       return {
-        replace: {...then.replace, information: playGetVoRuntimeInfoFromDataReference(then.replace.information, policyService, config.types).desc.name}
+        replace: {...then.replace, information: playGetVoRuntimeInfoFromDataReference(then.replace.information, service, config.types).desc.name}
       }
     }
 
     if(isDeleteInformation(then)) {
       return {
-        delete: {...then.delete, information: playGetVoRuntimeInfoFromDataReference(then.delete.information, policyService, config.types).desc.name}
+        delete: {...then.delete, information: playGetVoRuntimeInfoFromDataReference(then.delete.information, service, config.types).desc.name}
       }
     }
 

--- a/packages/play/src/queries/local-api-query.ts
+++ b/packages/play/src/queries/local-api-query.ts
@@ -1,16 +1,15 @@
 import {ApiQuery} from "@frontend/queries/use-api-query";
 import {getConfiguredPlayDocumentStore} from "@cody-play/infrastructure/multi-model-store/configured-document-store";
-import {filters} from "@event-engine/infrastructure/DocumentStore/Filter/index";
 import {asyncIteratorToArray} from "@event-engine/infrastructure/helpers/async-iterator-to-array";
 import {asyncMap} from "@event-engine/infrastructure/helpers/async-map";
-import {CarListDesc} from "@app/shared/types/fleet-management/car/car-list.desc";
-import {Car, car} from "@app/shared/types/fleet-management/car/car";
 import {CodyPlayConfig} from "@cody-play/state/config-store";
 import {CONTACT_PB_TEAM} from "@cody-play/infrastructure/error/message";
 import {
+  isQueryableListDescription,
+  isQueryableNotStoredStateDescription,
   isQueryableStateDescription,
   isQueryableStateListDescription,
-  isQueryableValueObjectDescription,
+  isQueryableValueObjectDescription, QueryableListDescription, QueryableNotStoredStateDescription,
   QueryableStateDescription,
   QueryableStateListDescription,
   QueryableValueObjectDescription
@@ -28,10 +27,19 @@ import {ResolveConfig} from "@cody-engine/cody/hooks/utils/value-object/types";
 import {
   makeFiltersFromQuerySchema,
   makeFiltersFromResolveConfig,
-  mapOrderByProp
 } from "@cody-play/queries/make-filters";
+import {mapOrderBy} from "@cody-engine/cody/hooks/utils/query/map-order-by";
+import {
+  playInformationServiceFactory
+} from "@cody-play/infrastructure/infromation-service/play-information-service-factory";
+import {INFORMATION_SERVICE_NAME} from "@server/infrastructure/information-service/information-service";
+import {validateResolverRules} from "@cody-engine/cody/hooks/utils/rule-engine/validate-resolver-rules";
+import {makeAsyncExecutable} from "@cody-play/infrastructure/rule-engine/make-executable";
+
+type ResolvedCtx = {query: Record<string, unknown>, meta: {user: User}, information?: unknown} & Record<string, unknown>;
 
 const ds = getConfiguredPlayDocumentStore();
+const infoService = playInformationServiceFactory();
 
 export const makeLocalApiQuery = (store: CodyPlayConfig, user: User): ApiQuery => {
   return async (queryName: string, params: any): Promise<any> => {
@@ -53,20 +61,69 @@ export const makeLocalApiQuery = (store: CodyPlayConfig, user: User): ApiQuery =
     const informationDesc = informationInfo.desc;
     const resolve = store.resolvers[queryName] || {};
 
+    let resolvedCtx: ResolvedCtx = {query: params, meta: {user}};
+
+    if(resolve.rules) {
+      const rulesCtx: Record<string, unknown> = {query: params, meta: {user}};
+      rulesCtx[INFORMATION_SERVICE_NAME] = infoService;
+
+      validateResolverRules(resolve.rules);
+
+      resolvedCtx = await (makeAsyncExecutable(resolve.rules))(rulesCtx);
+    }
+
+    if(isQueryableNotStoredStateDescription(informationDesc)) {
+      return await resolveNotStoredStateQuery(informationDesc, informationInfo.factory, queryInfo, resolvedCtx);
+    }
+
     if(isQueryableStateDescription(informationDesc)) {
-      return await resolveStateQuery(informationDesc, informationInfo.factory, queryInfo, params);
+      return await resolveStateQuery(informationDesc, informationInfo.factory, queryInfo, resolvedCtx.query);
     }
 
     if(isQueryableStateListDescription(informationDesc)) {
-      return await resolveStateListQuery(informationDesc, informationInfo.factory, queryInfo, resolve, params, user)
+      let itemInfo = store.types[informationDesc.itemType];
+
+      if(!itemInfo) {
+        // @TODO: throw exception, but ensure BC first
+        // throw new Error(`[CodyPlay] List item type "${informationDesc.itemType}" is unknown. Did you forget to pass it from prooph board to Cody Play?`)
+        itemInfo = informationInfo;
+      }
+
+      return await resolveStateListQuery(informationDesc, itemInfo.factory, queryInfo, resolve, resolvedCtx.query, user)
     }
 
     if(isQueryableValueObjectDescription(informationDesc)) {
-      return await resolveSingleValueObjectQuery(informationDesc, informationInfo.factory, queryInfo, resolve, params, user);
+      return await resolveSingleValueObjectQuery(informationDesc, informationInfo.factory, queryInfo, resolve, resolvedCtx.query, user);
+    }
+
+    if(isQueryableListDescription(informationDesc)) {
+      let itemInfo = store.types[informationDesc.itemType];
+
+      if(!itemInfo) {
+        // @TODO: throw exception, but ensure BC first
+        // throw new Error(`[CodyPlay] List item type "${informationDesc.itemType}" is unknown. Did you forget to pass it from prooph board to Cody Play?`)
+        itemInfo = informationInfo;
+      }
+
+      return await resolveNotStoredListQuery(informationDesc, itemInfo.factory, queryInfo, resolve, resolvedCtx);
     }
 
     throw new Error(`Cannot resolve query "${queryName}", because the query return type is not supported. ${CONTACT_PB_TEAM}`);
   }
+}
+
+const resolveNotStoredStateQuery = async (desc: QueryableNotStoredStateDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, ctx: ResolvedCtx): Promise<any> => {
+  const doc = ctx.information;
+
+  if(!doc) {
+    throw new NotFoundError(`"${desc.name}" with "${desc.identifier}": "${ctx.query[desc.identifier]}" not found!`);
+  }
+
+  console.log(`[CodyPlay] Performed not stored state query "${desc.name}" {${desc.identifier}: "${ctx.query[desc.identifier]}"}`, doc);
+
+  const exe = makeInformationFactory(factory);
+
+  return exe(doc);
 }
 
 const resolveStateQuery = async (desc: QueryableStateDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, params: any): Promise<any> => {
@@ -95,9 +152,7 @@ const resolveStateListQuery = async (desc: QueryableStateListDescription, factor
   let orderBy: SortOrder | undefined = undefined;
 
   if(resolve.orderBy) {
-    orderBy = Array.isArray(resolve.orderBy)
-      ? (resolve.orderBy as SortOrder).map(orderBy => mapOrderByProp(orderBy))
-      : [mapOrderByProp(resolve.orderBy as SortOrderItem)];
+    orderBy = mapOrderBy(resolve.orderBy);
   }
 
   const exe = makeInformationFactory(factory);
@@ -110,14 +165,14 @@ const resolveStateListQuery = async (desc: QueryableStateListDescription, factor
 const resolveSingleValueObjectQuery = async (desc: QueryableValueObjectDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, params: any, user: User): Promise<any> => {
   const queryPayload = determineQueryPayload(params, queryInfo as unknown as QueryRuntimeInfo);
 
-  const filters = resolve.where ? makeFiltersFromResolveConfig(desc, resolve, params, user) : makeFiltersFromQuerySchema(queryInfo.schema as JSONSchema7, params, user);
+  const filters = resolve.where
+    ? makeFiltersFromResolveConfig(desc, resolve, params, user) :
+      makeFiltersFromQuerySchema(queryInfo.schema as JSONSchema7, params, user);
 
   let orderBy: SortOrder | undefined = undefined;
 
   if(resolve.orderBy) {
-    orderBy = Array.isArray(resolve.orderBy)
-      ? (resolve.orderBy as SortOrder).map(orderBy => mapOrderByProp(orderBy))
-      : [mapOrderByProp(resolve.orderBy as SortOrderItem)];
+    orderBy = mapOrderBy(resolve.orderBy);
   }
 
   const exe = makeInformationFactory(factory);
@@ -133,5 +188,24 @@ const resolveSingleValueObjectQuery = async (desc: QueryableValueObjectDescripti
   console.log(`[CodyPlay] Performed state query "${desc.name}" {${filters}"}`, result[0]);
 
   return result[0];
+}
+
+const resolveNotStoredListQuery = async (desc: QueryableListDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, ctx: ResolvedCtx): Promise<any> => {
+  const exe = makeInformationFactory(factory);
+
+  if(!ctx.information) {
+    throw new Error(`[CodyPlay] Query resolver rules for ${desc.name} do not assign an "information" variable. The variable should contain the query result. Please check your prooph board query resolver rules.`)
+  }
+
+  const result = ctx.information;
+
+  if(!Array.isArray(result)) {
+    throw new Error(`[CodyPlay] Query resolver "information" result for ${desc.name} is not a list, but the data schema is defined as a list. Please check your prooph board query resolver rules.`)
+  }
+
+
+  console.log(`[CodyPlay] Performed list query "${desc.name}"`, ctx, result);
+
+  return result.map(item => exe(item));
 }
 

--- a/packages/play/src/queries/make-filters.ts
+++ b/packages/play/src/queries/make-filters.ts
@@ -3,7 +3,7 @@ import {User} from "@app/shared/types/core/user/user";
 import {filters} from "@event-engine/infrastructure/DocumentStore/Filter/index";
 import {QueryableStateListDescription, QueryableValueObjectDescription} from "@event-engine/descriptions/descriptions";
 import {ResolveConfig} from "@cody-engine/cody/hooks/utils/value-object/types";
-import {SortOrderItem} from "@event-engine/infrastructure/DocumentStore";
+import {SortOrder, SortOrderItem} from "@event-engine/infrastructure/DocumentStore";
 import {Filter as DSFilter} from "@event-engine/infrastructure/DocumentStore/Filter";
 import {
   isExecuteRules,
@@ -98,13 +98,6 @@ export const makeFiltersFromQuerySchema = (schema: JSONSchema7, params: any, use
   })
 
   return new filters.AndFilter(eqFilters[0], eqFilters[1], ...eqFilters.slice(2));
-}
-
-export const mapOrderByProp = (orderBy: SortOrderItem): SortOrderItem => {
-  return {
-    prop: `${orderBy.prop}`,
-    sort: orderBy.sort
-  }
 }
 
 const makeEqFilterFromProperty = (prop: string, params: any): DSFilter => {


### PR DESCRIPTION
Adds the possibility to execute rules in a query resolver. 

Rules are executed before the main query.
It's also possible to only execute rules. In that case the variable **information** needs to be assigned a value. It's passed into the VO factory function and then returned from the resolver.

With this change it is now possible to define non-state queries, meaning value objects can be queried (single VO or List of VOs) without the requirement that the VO has an identifier. So you can query scalar values or plain VOs like an address.

## How to use

Define a `rules` property in a resolver config:

```json
{
  "rules": [...]
}
```

## Query Rules

Two new rules are available:

### Find Information Rule

```js
{
  "rules": [
    {
      "rule": "always",
      "then": {
        "find": {
          "information": "/ReadModel/ReadModel",
          "filter": {}, // Same filter rules available as for the main query
          "skip": 10, // optional, can be used for pagination
          "limit": 10, // optional, can be used for pagination or limiting to specific number of results (e.g. 1)
          "orderBy": "property", // optional, string | object | array, string converts to {prop: 'property', sort: 'asc'}, array allows sorting by multiple props 
          "variable": "information"  // Default, can be omitted or changed to another variable that is used in further rules
        }
      }
    }
  ]
}
```

### Count Information Rule

```js
{
  "rules": [
    {
      "rule": "always",
      "then": {
        "count": {
          "information": "/ReadModel/ReadModel",
          "filter": {}, // Same filter rules available as for the main query           
          "variable": "information"  // Default, can be omitted or changed to another variable that is used in further rules
        }
      }
    }
  ]
}
```
