### PR TITLE
feat(user): define optional attributes

### DIFF
--- a/packages/play/src/app/components/core/PlayPersonaModal.tsx
+++ b/packages/play/src/app/components/core/PlayPersonaModal.tsx
@@ -26,7 +26,8 @@ const emptyPersona: Partial<Persona> = {
   roles: [],
   email: '',
   displayName: '',
-  description: ''
+  description: '',
+  attributes: {},
 }
 
 const PersonaSchema = {
@@ -47,6 +48,11 @@ const PersonaSchema = {
         title: "Roles",
         items: {type: "string", default: "Anyone", title: 'Role'},
         minItems: 1
+      },
+      attributes: {
+        type: "object",
+        title: "Attributes",
+        additionalProperties: true
       }
     }
   }
@@ -98,7 +104,7 @@ const PlayPersonaModal = (props: PlayPersonaModalProps) => {
     });
 
     changedPersonas.unshift(config.personas[0]);
-    debugger;
+
     dispatch({
       type: "SET_PERSONAS",
       personas: changedPersonas

--- a/packages/shared/src/lib/jexl/get-configured-jexl.ts
+++ b/packages/shared/src/lib/jexl/get-configured-jexl.ts
@@ -15,6 +15,7 @@ const getConfiguredJexl = (): Jexl => {
     configuredJexl.addFunction('count', count);
     configuredJexl.addFunction('uuid', generateUuuid);
     configuredJexl.addFunction('isRole', isRole);
+    configuredJexl.addFunction('userAttr', getAttribute);
 
     registerArrayExtensions(configuredJexl);
     registerDateTimeExtensions(configuredJexl);
@@ -51,6 +52,18 @@ const generateUuuid = () => {
 
 const isRole = (user: User, role: UserRole): boolean => {
   return user.roles.includes(role);
+}
+
+const getAttribute = (user: User, attrName: string, notSetValue: any = null): any => {
+  if(!user.attributes) {
+    return notSetValue;
+  }
+
+  if(typeof user.attributes[attrName] === "undefined") {
+    return notSetValue;
+  }
+
+  return user.attributes[attrName];
 }
 
 export default getConfiguredJexl();

--- a/packages/shared/src/lib/types/core/user/user.ts
+++ b/packages/shared/src/lib/types/core/user/user.ts
@@ -5,7 +5,8 @@ interface UserProps {
   userId: string;
   email: string;
   avatar?: string;
-  roles: UserRole[],
+  roles: UserRole[];
+  attributes?: Record<string, unknown>;
 }
 
 export type User = Readonly<UserProps>;


### PR DESCRIPTION
Adds an optional `attributes` record to the `User` object.

Attributes can be configured for personas in Cody Play.

A Jexl helper function `userAttr<T>(user: User, name: string, notSetValue: T) => T` is also added to simplify working with attributes in if statements etc.