### PR TITLE
feat(widgets): Add FilteredEnum widget

### DIFF
--- a/packages/fe/src/app/components/core/CommandForm.tsx
+++ b/packages/fe/src/app/components/core/CommandForm.tsx
@@ -30,6 +30,7 @@ import {getRjsfValidator} from "@frontend/util/rjsf-validator";
 import {DeepReadonly} from "json-schema-to-ts/lib/types/type-utils/readonly";
 import {JSONSchema7} from "json-schema";
 import {cloneDeepJSON} from "@frontend/util/clone-deep-json";
+import {usePageData} from "@frontend/hooks/use-page-data";
 
 interface OwnProps {
   command: CommandRuntimeInfo;
@@ -58,6 +59,7 @@ const CommandForm = (props: CommandFormProps, ref: any) => {
   const [liveValidate, setLiveValidate] = useState(false);
   const [submittedFormData, setSubmittedFormData] = useState<{[prop: string]: any}>();
   const [user,] = useUser();
+  const [pageData,] = usePageData();
   const mutation = useMutation({
     mutationKey: [props.command.desc.name],
     mutationFn: props.commandFn,
@@ -134,7 +136,7 @@ const CommandForm = (props: CommandFormProps, ref: any) => {
 
   const mainUiSchema = props.command.uiSchema ? props.command.uiSchema : undefined;
   const resolvedUiSchema = resolveUiSchema(props.command.schema as any, types);
-  const uiSchema = normalizeUiSchema({...resolvedUiSchema, ...mainUiSchema}, {data: formData, user});
+  const uiSchema = normalizeUiSchema({...resolvedUiSchema, ...mainUiSchema}, {form: formData, user, page: pageData});
 
   const schema = resolveRefs(cloneSchema(props.command.schema as any), props.definitions) as RJSFSchema;
 
@@ -156,7 +158,7 @@ const CommandForm = (props: CommandFormProps, ref: any) => {
               ref={(form) => formRef = form}
               onSubmit={handleSubmit}
               formData={formData}
-              formContext={formData}
+              formContext={{data: formData}}
               uiSchema={uiSchema}
               liveValidate={liveValidate}
               showErrorList={false}

--- a/packages/fe/src/app/components/core/StateView.tsx
+++ b/packages/fe/src/app/components/core/StateView.tsx
@@ -116,6 +116,7 @@ export const ArrayFieldTemplate = (props: PropsWithChildren<ArrayFieldTemplatePr
 const StateView = (props: StateViewProps) => {
   const theme = useTheme();
   const [user,] = useUser();
+  const [pageData,] = useUser();
 
   const resolvedUiSchema = resolveUiSchema(props.description.schema as any, types);
   const mainUiSchema = props.description.uiSchema;
@@ -123,7 +124,7 @@ const StateView = (props: StateViewProps) => {
   const uiSchema = Object.keys(mergedUiSchema).length > 0
     ? {
       "ui:readonly": true,
-      ...normalizeUiSchema(mergedUiSchema, {data: props.state, user})
+      ...normalizeUiSchema(mergedUiSchema, {form: props.state, user, page: pageData})
     }
     : {"ui:readonly": true};
 
@@ -142,6 +143,7 @@ const StateView = (props: StateViewProps) => {
         validator={getRjsfValidator()}
         children={<></>}
         formData={props.state}
+        formContext={{data: props.state}}
         uiSchema={uiSchema}
         className="stateview"
         templates={

--- a/packages/fe/src/app/components/core/form/widgets.ts
+++ b/packages/fe/src/app/components/core/form/widgets.ts
@@ -1,8 +1,10 @@
 import {Widget} from "@rjsf/utils";
 import DataSelectWidget from "@frontend/app/components/core/form/widgets/DataSelectWidget";
+import FilteredEnumWidget from "@frontend/app/components/core/form/widgets/FilteredEnumWidget";
 
 export type WidgetRegistry = {[widgetName: string]: Widget};
 
 export const widgets: WidgetRegistry = {
   DataSelect: DataSelectWidget,
+  FilteredEnum: FilteredEnumWidget,
 }

--- a/packages/fe/src/app/components/core/form/widgets/FilteredEnumWidget.tsx
+++ b/packages/fe/src/app/components/core/form/widgets/FilteredEnumWidget.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import {WidgetProps} from "@rjsf/utils";
+import {useUser} from "@frontend/hooks/use-user";
+import {usePageData} from "@frontend/hooks/use-page-data";
+import {useParams} from "react-router-dom";
+import jexl from "@app/shared/jexl/get-configured-jexl";
+
+interface OwnProps {
+
+}
+
+type FilteredEnumWidgetProps = OwnProps & WidgetProps;
+
+const FilteredEnumWidget = (props: FilteredEnumWidgetProps) => {
+  const SelectWidget = props.registry.widgets.SelectWidget;
+  const [user,] = useUser();
+  const [pageData,] = usePageData();
+  const routeParams = useParams();
+
+  const jexlCtx = {...routeParams, form: props.formContext?.data || {}, user, page: pageData}
+
+  const enumVals = props.options.enumOptions || [];
+  const filter = props.options.filter as string || 'true';
+  const map = props.options.map as string || 'item';
+
+  const filteredProps = {
+    ...props, options: {
+      ...props.options,
+      enumOptions: enumVals
+        .filter(item => jexl.evalSync(filter, {...jexlCtx, item: item}))
+        .map(item => jexl.evalSync(map, {...jexlCtx, item: item}))
+    }
+  };
+
+  return <SelectWidget {...filteredProps} />
+};
+
+export default FilteredEnumWidget;

--- a/packages/shared/src/lib/jexl/array-extension/register.ts
+++ b/packages/shared/src/lib/jexl/array-extension/register.ts
@@ -2,7 +2,10 @@ import {Jexl} from "@event-engine/infrastructure/jexl/jexl";
 
 export const registerArrayExtensions = (jexl: Jexl): void => {
   jexl.addFunction('push', arrayPush);
+  jexl.addFunction('contains', arrayContains);
   jexl.addFunction('filter', (arr: Array<unknown>, expr: string, ctx: object) => filter(arr, expr, ctx, jexl));
+  jexl.addFunction('map', (arr: Array<unknown>, expr: string, ctx: object) => map(arr, expr, ctx, jexl));
+  jexl.addFunction('join', (arr: Array<unknown>, separator?: string) => arr.join(separator));
 }
 
 const arrayPush = (arr: Array<unknown>, val: unknown): Array<unknown> => {
@@ -12,6 +15,14 @@ const arrayPush = (arr: Array<unknown>, val: unknown): Array<unknown> => {
   const copy = [...arr];
   copy.push(val);
   return copy;
+}
+
+const arrayContains = (arr: Array<unknown>, val: unknown): boolean => {
+  if(!Array.isArray(arr)) {
+    return false;
+  }
+
+  return arr.includes(val);
 }
 
 const filter = (arr: Array<unknown>, expr: string, ctx: object, jexl: Jexl): Array<unknown> => {
@@ -30,6 +41,16 @@ const filter = (arr: Array<unknown>, expr: string, ctx: object, jexl: Jexl): Arr
   })
 
   return filtered;
+}
+
+const map = (arr: Array<unknown>, expr: string, ctx: object, jexl: Jexl): Array<unknown> => {
+  if(!Array.isArray(arr)) {
+    throw new Error(`First argument of jexl map() needs to be an array. ${typeof arr} given.`);
+  }
+
+  return arr.map(item => {
+    return jexl.evalSync(expr, {...ctx, item});
+  })
 }
 
 

--- a/packages/shared/src/lib/jexl/get-configured-jexl.ts
+++ b/packages/shared/src/lib/jexl/get-configured-jexl.ts
@@ -7,6 +7,7 @@ import {UserRole} from "@app/shared/types/core/user/user-role";
 import {registerArrayExtensions} from "@app/shared/jexl/array-extension/register";
 import {registerDateTimeExtensions} from "@app/shared/jexl/datetime-extension/register";
 import {PageData} from "@app/shared/types/core/page-data/page-data";
+import {registerStringExtensions} from "@app/shared/jexl/string-extension/register";
 
 let configuredJexl: Jexl;
 
@@ -14,11 +15,13 @@ const getConfiguredJexl = (): Jexl => {
   if(!configuredJexl) {
     configuredJexl = new jexl.Jexl() as Jexl;
     configuredJexl.addFunction('count', count);
+    configuredJexl.addFunction('merge', merge);
     configuredJexl.addFunction('uuid', generateUuuid);
     configuredJexl.addFunction('isRole', isRole);
     configuredJexl.addFunction('userAttr', getAttribute);
     configuredJexl.addFunction('pageData', getPageData);
 
+    registerStringExtensions(configuredJexl);
     registerArrayExtensions(configuredJexl);
     registerDateTimeExtensions(configuredJexl);
 
@@ -46,6 +49,24 @@ const count = (val: any) => {
   }
 
   return val ? 1 : 0;
+}
+
+const merge = (val1: any, val2: any) => {
+  if(Array.isArray(val1)) {
+    if(!Array.isArray(val2)) {
+      val2 = [val2];
+    }
+    return [...val1, ...val2];
+  }
+
+  if(typeof val1 === "object") {
+    if(typeof val2 !== "object") {
+      val2 = {merged: val2};
+    }
+    return {...val1, ...val2};
+  }
+
+  return val1.toString() + val2.toString();
 }
 
 const generateUuuid = () => {

--- a/packages/shared/src/lib/jexl/string-extension/register.ts
+++ b/packages/shared/src/lib/jexl/string-extension/register.ts
@@ -1,0 +1,7 @@
+import {Jexl} from "@event-engine/infrastructure/jexl/jexl";
+
+export const registerStringExtensions = (jexl: Jexl): void => {
+  jexl.addFunction('upperCase', (str: string) => str.toUpperCase());
+  jexl.addFunction('lowerCase', (str: string) => str.toLowerCase());
+  jexl.addFunction('split', (str: string, separator: string) => str.split(separator));
+}


### PR DESCRIPTION
Adds a new widget: FilteredEnum

```json
  "property": {
    "ui:widget": "FilteredEnum",
    "ui:options": {
      "filter": "item.value != 'someValue'",
      "map": "merge(item, {label: upperCase(item.label)})"
    }
  }
```

Also adds a filter option to DataSelectWidget

`page, user, form` is available in jexl context of DataSelectWidget and FilteredEnum

## BC Break

- jexl context in uiSchema receives form data as `form` attribute (instead of `data`)
