### PR TITLE
feat(Tabs): Introduce page tabs

### DIFF
--- a/packages/cody/src/lib/hooks/ui-files/page-files/sub-level/__service__/__fileName__.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/ui-files/page-files/sub-level/__service__/__fileName__.ts__tmpl__
@@ -8,6 +8,7 @@ export const <%= className %>: SubLevelPageWithProophBoardDescription = {
   route: "<%= route %>",
   routeParams: <%- toJSON(routeParams) %>,
   breadcrumb: <%- breadcrumb %>,
+  <% if (isTab) { %>tab: <%- toJSON(tab) %>,<% } %>
   _pbBoardId: "<%= _pbBoardId %>",
   _pbCardId: "<%= _pbCardId %>",
   _pbCreatedBy: "<%= _pbCreatedBy %>",

--- a/packages/cody/src/lib/hooks/ui-files/page-files/top-level/__service__/__fileName__.ts__tmpl__
+++ b/packages/cody/src/lib/hooks/ui-files/page-files/top-level/__service__/__fileName__.ts__tmpl__
@@ -12,6 +12,7 @@ export const <%= className %>: TopLevelPageWithProophBoardDescription = {
     <% if (typeof sidebar.invisible !== "undefined") { %>invisible: <%- toJSON(sidebar.invisible) %>,<% } %>
   },
   breadcrumb: <%- breadcrumb %>,
+  <% if (isTab) { %>tab: <%- toJSON(tab) %>,<% } %>
   _pbBoardId: "<%= _pbBoardId %>",
   _pbCardId: "<%= _pbCardId %>",
   _pbCreatedBy: "<%= _pbCreatedBy %>",

--- a/packages/cody/src/lib/hooks/utils/ui/get-ui-metadata.ts
+++ b/packages/cody/src/lib/hooks/utils/ui/get-ui-metadata.ts
@@ -6,7 +6,7 @@ import {UiMetadata} from "@cody-engine/cody/hooks/utils/ui/types";
 
 export const getUiMetadata = (ui: Node, ctx: Context): UiMetadata | CodyResponse => {
   // @todo: validate ui meta
-  const meta = parseJsonMetadata(ui) as UiMetadata;
+  const meta = parseJsonMetadata(ui) as UiMetadata & {sidebar?: {hidden?: string}};
 
   if(isCodyError(meta)) {
     return meta;
@@ -14,6 +14,14 @@ export const getUiMetadata = (ui: Node, ctx: Context): UiMetadata | CodyResponse
 
   if(meta && meta.sidebar?.icon) {
     meta.sidebar.icon = names(meta.sidebar.icon).className;
+  }
+
+  if(meta && meta.tab?.icon) {
+    meta.tab.icon = names(meta.tab.icon).className;
+  }
+
+  if(meta && meta.sidebar && meta.sidebar.hidden) {
+    meta.sidebar.invisible = meta.sidebar.hidden;
   }
 
   return meta;

--- a/packages/cody/src/lib/hooks/utils/ui/types.ts
+++ b/packages/cody/src/lib/hooks/utils/ui/types.ts
@@ -1,4 +1,6 @@
 import {Rule} from "@cody-engine/cody/hooks/utils/rule-engine/configuration";
+import {SxProps} from "@mui/material";
+import {Tab} from "@frontend/app/pages/page-definitions";
 
 export interface DynamicBreadcrumbMetadata {
   data: string;
@@ -10,6 +12,7 @@ export interface UiMetadata {
   routeParams?: string[];
   sidebar?: { label?: string; icon?: string; show?: boolean | Rule[], invisible?: string };
   breadcrumb?: string | DynamicBreadcrumbMetadata;
+  tab?: Tab;
 }
 
 export const isDynamicBreadcrumb = (breadcrumb: string | DynamicBreadcrumbMetadata | undefined): breadcrumb is DynamicBreadcrumbMetadata => {

--- a/packages/cody/src/lib/hooks/utils/ui/upsert-page-definition.ts
+++ b/packages/cody/src/lib/hooks/utils/ui/upsert-page-definition.ts
@@ -67,7 +67,7 @@ export const upsertTopLevelPage = async (
     return allowedRoles;
   }
 
-  const invisible = allowedRoles.count() ? convertToRoleCheck(allowedRoles): undefined;
+  const invisible = allowedRoles.count() ? convertToRoleCheck(allowedRoles): uiMeta.sidebar?.invisible;
 
   const sidebarIcon = uiMeta.sidebar?.icon || 'SquareRoundedOutline';
 
@@ -79,6 +79,8 @@ export const upsertTopLevelPage = async (
     invisible,
   };
 
+  const isTab = !!uiMeta.tab;
+
   generateFiles(tree, __dirname + '/../../ui-files/page-files/top-level', ctx.feSrc + '/app/pages', {
     ...pbInfo,
     tmpl: '',
@@ -86,6 +88,8 @@ export const upsertTopLevelPage = async (
     ...uiNames,
     route,
     sidebar,
+    isTab,
+    tab: uiMeta.tab,
     toJSON,
     breadcrumb,
     imports: imports.join(";\n"),
@@ -139,6 +143,8 @@ export const upsertSubLevelPage = async (
 
   const [breadcrumb, breadcrumbImports] = breadcrumbInfo;
 
+  const isTab = !!uiMeta.tab;
+
   generateFiles(tree, __dirname + '/../../ui-files/page-files/sub-level', ctx.feSrc + '/app/pages', {
     ...pbInfo,
     tmpl: '',
@@ -146,6 +152,8 @@ export const upsertSubLevelPage = async (
     ...uiNames,
     route,
     routeParams,
+    isTab,
+    tab: uiMeta.tab,
     toJSON,
     breadcrumb,
     breadcrumbImports: breadcrumbImports.join(";\n"),

--- a/packages/fe/src/app/pages/page-definitions.ts
+++ b/packages/fe/src/app/pages/page-definitions.ts
@@ -1,5 +1,5 @@
 import {QueryClient} from "@tanstack/react-query";
-import {SvgIcon} from "@mui/material";
+import {SvgIcon, SxProps} from "@mui/material";
 import {ProophBoardDescription} from "@event-engine/descriptions/descriptions";
 
 export type UnsubscribeBreadcrumbListener = () => void;
@@ -11,6 +11,7 @@ export interface PageDefinition {
   breadcrumb: BreadcrumbFn;
   components: string[];
   commands: string[];
+  tab?: Omit<Tab, "route">;
 }
 
 export interface TopLevelPage extends PageDefinition {
@@ -20,6 +21,17 @@ export interface TopLevelPage extends PageDefinition {
 export interface TopLevelGroup {
   label: string,
   icon: string,
+}
+
+export interface Tab {
+  group: string;
+  label: string;
+  route: string;
+  icon?: string;
+  style?: SxProps;
+  styleExpr?: string;
+  hidden?: string;
+  disabled?: string;
 }
 
 export type TopLevelPageWithProophBoardDescription = TopLevelPage & ProophBoardDescription;

--- a/packages/fe/src/app/pages/standard-page.tsx
+++ b/packages/fe/src/app/pages/standard-page.tsx
@@ -1,13 +1,22 @@
-import {PageDefinition} from "@frontend/app/pages/page-definitions";
+import {PageDefinition, Tab} from "@frontend/app/pages/page-definitions";
 import Grid2 from "@mui/material/Unstable_Grid2";
-import {useParams} from "react-router-dom";
+import {generatePath, useParams} from "react-router-dom";
 import CommandBar from "@frontend/app/layout/CommandBar";
 import {loadCommandComponent} from "@frontend/util/components/load-command-components";
-import {views as viewComponents} from "@frontend/app/components/views";
 import {loadViewComponent} from "@frontend/util/components/load-view-components";
+import {PageRegistry, pages} from "@frontend/app/pages/index";
 
 interface Props {
   page: PageDefinition
+}
+
+const findTabGroup = (groupName: string, pages: PageRegistry, routeParams: Readonly<Record<string, string>>): Tab[] => {
+  return Object.values(pages).filter(p => p.tab && p.tab.group === groupName).map(p => {
+    return {
+      ...p.tab!,
+      route: generatePath(p.route, routeParams)
+    }
+  });
 }
 
 export const StandardPage = (props: Props) => {
@@ -18,7 +27,13 @@ export const StandardPage = (props: Props) => {
     return <Command key={commandName} {...routeParams} />
   });
 
-  const commandBar = cmdBtns.length ? <Grid2 xs={12}><CommandBar>{cmdBtns}</CommandBar></Grid2> : <></>;
+  let tabs;
+
+  if(props.page.tab) {
+    tabs = findTabGroup(props.page.tab.group, pages, routeParams as Readonly<Record<string, string>>);
+  }
+
+  const commandBar = cmdBtns.length || tabs ? <Grid2 xs={12}><CommandBar tabs={tabs}>{cmdBtns}</CommandBar></Grid2> : <></>;
 
   const components = props.page.components.map((valueObjectName, index) => {
     const ViewComponent = loadViewComponent(valueObjectName);

--- a/packages/play/src/app/app.tsx
+++ b/packages/play/src/app/app.tsx
@@ -14,7 +14,7 @@ import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
 import queryClient from "@frontend/extensions/http/configured-react-query";
 import MainLayout from "@cody-play/app/layout/MainLayout";
-import React, {useContext, useEffect, useRef, useState} from "react";
+import React, {useContext, useEffect, useState} from "react";
 import {SnackbarProvider} from "notistack";
 import ScrollToTop from "@frontend/app/components/core/ScrollToTop";
 import User from "@frontend/app/providers/User";
@@ -30,8 +30,7 @@ import CodyMessageServerInjection from "@cody-play/app/components/core/CodyMessa
 import {getConfiguredPlayEventStore} from "@cody-play/infrastructure/multi-model-store/configured-event-store";
 import {PlayStreamListener} from "@cody-play/infrastructure/multi-model-store/make-stream-listener";
 import PlayToggleColorMode from "@cody-play/app/layout/PlayToggleColorMode";
-import PendingChanges, {PendingChangesContext} from "@cody-play/infrastructure/multi-model-store/PendingChanges";
-import {MessageBox} from "@event-engine/messaging/message-box";
+import PendingChanges from "@cody-play/infrastructure/multi-model-store/PendingChanges";
 import {getConfiguredPlayMessageBox} from "@cody-play/infrastructure/message-box/configured-message-box";
 import {PlayMessageBox} from "@cody-play/infrastructure/message-box/play-message-box";
 import {

--- a/packages/play/src/infrastructure/cody/hooks/on-ui.ts
+++ b/packages/play/src/infrastructure/cody/hooks/on-ui.ts
@@ -79,8 +79,6 @@ export const onUi = async (ui: Node, dispatch: PlayConfigDispatch, ctx: ElementE
       mergedCommands.push(...commands.toArray());
     }
 
-    let invisible: string | undefined;
-
     const page = topLevelPage ? ({
       service: serviceNames.className,
       route,
@@ -92,6 +90,7 @@ export const onUi = async (ui: Node, dispatch: PlayConfigDispatch, ctx: ElementE
         icon: 'square'
       },
       breadcrumb: meta.breadcrumb,
+      tab: meta.tab,
     } as PlayTopLevelPage) : ({
       service: serviceNames.className,
       route,
@@ -99,7 +98,8 @@ export const onUi = async (ui: Node, dispatch: PlayConfigDispatch, ctx: ElementE
       commands: mergedCommands,
       components: mergedComponents,
       topLevel: false,
-      breadcrumb: meta.breadcrumb
+      breadcrumb: meta.breadcrumb,
+      tab: meta.tab,
     } as PlaySubLevelPage);
 
     dispatch({

--- a/packages/play/src/infrastructure/cody/ui/play-ui-metadata.ts
+++ b/packages/play/src/infrastructure/cody/ui/play-ui-metadata.ts
@@ -10,7 +10,7 @@ import {playConvertToRoleCheck} from "@cody-play/infrastructure/role/play-conver
 export type PlayUiMetadata = UiMetadata & {sidebar?: {label: string, icon: string, invisible: string}};
 
 export const playUiMetadata = (ui: Node, ctx: ElementEditedContext): PlayUiMetadata | CodyResponse => {
-  const meta = playParseJsonMetadata(ui) as UiMetadata;
+  const meta = playParseJsonMetadata(ui) as UiMetadata & {sidebar?: {hidden?: string}};
 
   if(playIsCodyError(meta)) {
     return meta;
@@ -22,6 +22,10 @@ export const playUiMetadata = (ui: Node, ctx: ElementEditedContext): PlayUiMetad
     metadata.sidebar.icon = names(metadata.sidebar.icon).className;
   }
 
+  if(metadata.tab?.icon) {
+    metadata.tab.icon = names(metadata.tab.icon).className;
+  }
+
   if(metadata.sidebar) {
     const allowedRoles = playAllowedRoles(ui, ctx);
 
@@ -29,7 +33,11 @@ export const playUiMetadata = (ui: Node, ctx: ElementEditedContext): PlayUiMetad
       return allowedRoles;
     }
 
-    metadata.sidebar.invisible = allowedRoles.count() ? playConvertToRoleCheck(allowedRoles) : undefined;
+    if(metadata.sidebar.hidden) {
+      metadata.sidebar.invisible = metadata.sidebar.hidden;
+    }
+
+    metadata.sidebar.invisible = allowedRoles.count() ? playConvertToRoleCheck(allowedRoles) : metadata.sidebar.invisible;
   }
 
   return metadata as PlayUiMetadata;


### PR DESCRIPTION
Pages can now be organized into tabs. For this you have to configure a tab group by adding a tab configuration to each UI card that is part of the group:

```json
{  
  "route": "/brands/:brandId",
  "routeParams": [
    "brandId"
  ],
  "breadcrumb": {
    "data": "/Car/Brand",
    "label": "data.name"
  },
  "tab": {
    "group": "brand",
    "label": "Brand Details"
  }
}
```

Tabs can have an `icon`, be `disabled` (jexl expr) or `hidden` (jexl expr) and be `style` d (SxProps) or with jexl expr: `styleExpr`