### PR TITLE
feat: Provide container info to action bars

### DIFF
--- a/packages/fe/src/app/components/core/CommandDialog.tsx
+++ b/packages/fe/src/app/components/core/CommandDialog.tsx
@@ -37,6 +37,7 @@ import Grid2 from "@mui/material/Unstable_Grid2";
 import TopRightActions from "@frontend/app/components/core/actions/TopRightActions";
 import {getObjPropTitleStyle} from "@frontend/app/components/core/form/templates/ObjectFieldTemplate";
 import commandForm from "@frontend/app/components/core/CommandForm";
+import {ActionContainerInfo} from "@frontend/app/components/core/form/types/action";
 
 export interface AggregateIdentifier {
   identifier: string;
@@ -224,6 +225,11 @@ const CommandDialog = (props: CommandDialogProps) => {
     data: commandFormRef.current?.getData() || {}
   }, env);
 
+  const containerInfo: ActionContainerInfo = {
+    name: props.commandDialogCommand.desc.name,
+    type: "command"
+  }
+
   return (
     <Dialog open={props.open} fullWidth={true} maxWidth={'lg'} onClose={handleCancel} sx={{"& .MuiDialog-paper": {minHeight: "50%"}}}>
       <DialogTitle sx={{
@@ -234,11 +240,15 @@ const CommandDialog = (props: CommandDialogProps) => {
           <Grid2 xs sx={{padding: theme.spacing(2)}}>
             {title && <Typography variant={"h2"}>{title}</Typography>}
           </Grid2>
-          <TopRightActions uiOptions={uiOptions} defaultService={env.DEFAULT_SERVICE} jexlCtx={jexlCtx} additionalRightButtons={[
-            <IconButton onClick={handleCancel} sx={{color: theme.palette.grey[500]}}>
-              <Close />
-            </IconButton>
-          ]} />
+          <TopRightActions uiOptions={uiOptions}
+                           containerInfo={containerInfo}
+                           defaultService={env.DEFAULT_SERVICE}
+                           jexlCtx={jexlCtx}
+                           additionalRightButtons={[
+                            <IconButton onClick={handleCancel} sx={{color: theme.palette.grey[500]}}>
+                              <Close />
+                            </IconButton>
+                          ]} />
         </Grid2>
       </DialogTitle>
       <DialogContent sx={{

--- a/packages/fe/src/app/components/core/FormView.tsx
+++ b/packages/fe/src/app/components/core/FormView.tsx
@@ -274,7 +274,15 @@ const FormView = (props: FormViewProps) => {
       }}
     />
     {extraError && <Box sx={{paddingTop: `${theme.spacing(4)}`}} id={extraErrorId()}>{extraError}</Box>}
-    <BottomActions sx={{padding:  `${theme.spacing(4)} 0`}} uiOptions={uiOptions} defaultService={defaultService} jexlCtx={jexlCtx} />
+    <BottomActions sx={{padding:  `${theme.spacing(4)} 0`}}
+                   containerInfo={{
+                     name: infoFQCN,
+                     type: "view"
+                   }}
+                   uiOptions={uiOptions}
+                   defaultService={defaultService}
+                   jexlCtx={jexlCtx}
+    />
   </Box>;
 };
 

--- a/packages/fe/src/app/components/core/StateView.tsx
+++ b/packages/fe/src/app/components/core/StateView.tsx
@@ -143,7 +143,14 @@ const StateView = (props: StateViewProps) => {
         ...props.fields
       }}
     />
-    <BottomActions sx={{padding:  `${theme.spacing(4)} 0`}} uiOptions={uiOptions} defaultService={defaultService} jexlCtx={jexlCtx} />
+    <BottomActions sx={{padding:  `${theme.spacing(4)} 0`}}
+                   containerInfo={{
+                     name: infoFQCN,
+                     type: "view"
+                   }}
+                   uiOptions={uiOptions}
+                   defaultService={defaultService}
+                   jexlCtx={jexlCtx} />
   </Box>;
 };
 

--- a/packages/fe/src/app/components/core/actions/BottomActions.tsx
+++ b/packages/fe/src/app/components/core/actions/BottomActions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {FormJexlContext} from "@frontend/app/components/core/form/types/form-jexl-context";
-import {Action} from "@frontend/app/components/core/form/types/action";
+import {Action, ActionContainerInfo} from "@frontend/app/components/core/form/types/action";
 import Grid2 from "@mui/material/Unstable_Grid2";
 import ActionButton from "@frontend/app/components/core/ActionButton";
 import {SxProps} from "@mui/material";
@@ -14,9 +14,10 @@ interface OwnProps {
   jexlCtx: FormJexlContext;
   sx?: SxProps;
   actions?: Action[];
-  additionalLeftButtons?: JSX.Element[],
-  additionalCenterButtons?: JSX.Element[],
-  additionalRightButtons?: JSX.Element[],
+  additionalLeftButtons?: JSX.Element[];
+  additionalCenterButtons?: JSX.Element[];
+  additionalRightButtons?: JSX.Element[];
+  containerInfo?: ActionContainerInfo;
 }
 
 type BottomActionsProps = OwnProps;

--- a/packages/fe/src/app/components/core/actions/TopRightActions.tsx
+++ b/packages/fe/src/app/components/core/actions/TopRightActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Action} from "@frontend/app/components/core/form/types/action";
+import {Action, ActionContainerInfo} from "@frontend/app/components/core/form/types/action";
 import {FormJexlContext} from "@frontend/app/components/core/form/types/form-jexl-context";
 import Grid2 from "@mui/material/Unstable_Grid2";
 import ActionButton from "@frontend/app/components/core/ActionButton";
@@ -13,6 +13,7 @@ interface OwnProps {
   jexlCtx: FormJexlContext;
   actions?: Action[];
   additionalRightButtons?: JSX.Element[];
+  containerInfo?: ActionContainerInfo;
 }
 
 type TopRightActionsProps = OwnProps;

--- a/packages/fe/src/app/components/core/form/templates/ArrayFieldTemplate.tsx
+++ b/packages/fe/src/app/components/core/form/templates/ArrayFieldTemplate.tsx
@@ -62,9 +62,10 @@ export const ArrayFieldTemplate = <
   }
 
   let idPrefix = 'component_' + names(props.title).fileName + '_';
+  let fqcn = '';
 
   if(props.schema.$id) {
-    const fqcn = playFQCNFromDefinitionId(props.schema.$id);
+    fqcn = playFQCNFromDefinitionId(props.schema.$id);
 
     idPrefix = 'component_' + names(fqcn).fileName + '_';
   }
@@ -96,7 +97,11 @@ export const ArrayFieldTemplate = <
                                 className={(headingVariant === 'h3' || headingVariant === 'h4') ? 'sidebar-anchor' : ''}
                                 sx={getObjPropTitleStyle(headingVariant, theme, mode)}>{title}{index}</Typography>}
         </Grid2>
-        <TopRightActions  uiOptions={uiOptions} defaultService={props.formContext!.defaultService} jexlCtx={jexlCtx} />
+        <TopRightActions  uiOptions={uiOptions}
+                          containerInfo={nestingLevel === 1 ? {name: fqcn, type: "mixed"} : undefined}
+                          defaultService={props.formContext!.defaultService}
+                          jexlCtx={jexlCtx}
+        />
       </Grid2>
       <Grid2 xs={12} {...gridConfig as Grid2Props}>
         <ArrayFieldDescriptionTemplate
@@ -125,18 +130,22 @@ export const ArrayFieldTemplate = <
         </Grid2>
       </Grid2>}
     </Grid2>
-    {(isDialogMode(mode) || nestingLevel > 1) && <BottomActions sx={{padding: nestingLevel === 1 ? `0 ${theme.spacing(2)}` : 0}} uiOptions={uiOptions}
-                    defaultService={props.formContext!.defaultService} jexlCtx={jexlCtx} additionalRightButtons={
-      isWriteMode(mode) && props.canAdd ? [
-        <AddButton
-          key={'array_field_' + props.idSchema.$id + 'add_button'}
-          className='array-item-add'
-          onClick={props.onAddClick}
-          disabled={props.disabled || props.readonly}
-          uiSchema={props.uiSchema}
-          registry={props.registry}
-        />
-      ] : undefined
+    {(isDialogMode(mode) || nestingLevel > 1) && <BottomActions
+      sx={{padding: nestingLevel === 1 ? `0 ${theme.spacing(2)}` : 0}}
+      containerInfo={nestingLevel === 1 ? {name: fqcn, type: "mixed"} : undefined}
+      uiOptions={uiOptions}
+      defaultService={props.formContext!.defaultService}
+      jexlCtx={jexlCtx} additionalRightButtons={
+        isWriteMode(mode) && props.canAdd ? [
+          <AddButton
+            key={'array_field_' + props.idSchema.$id + 'add_button'}
+            className='array-item-add'
+            onClick={props.onAddClick}
+            disabled={props.disabled || props.readonly}
+            uiSchema={props.uiSchema}
+            registry={props.registry}
+          />
+        ] : undefined
     }/>}
   </>)
 }

--- a/packages/fe/src/app/components/core/form/templates/ObjectFieldTemplate.tsx
+++ b/packages/fe/src/app/components/core/form/templates/ObjectFieldTemplate.tsx
@@ -203,9 +203,10 @@ export default function ObjectFieldTemplate<
   }
 
   let idPrefix = 'component_' + names(props.title).fileName + '_';
+  let fqcn = '';
 
   if(props.schema.$id) {
-    const fqcn = playFQCNFromDefinitionId(props.schema.$id);
+    fqcn = playFQCNFromDefinitionId(props.schema.$id);
 
     idPrefix = 'component_' + names(fqcn).fileName + '_';
   }
@@ -231,7 +232,10 @@ export default function ObjectFieldTemplate<
             registry={props.registry}
           />}
         </Grid2>
-        <TopRightActions uiOptions={uiOptions} defaultService={props.formContext!.defaultService} jexlCtx={jexlCtx}/>
+        <TopRightActions uiOptions={uiOptions}
+                         containerInfo={nestingLevel === 1 ? {name: fqcn, type: "mixed"} : undefined}
+                         defaultService={props.formContext!.defaultService}
+                         jexlCtx={jexlCtx}/>
       </Grid2>}
       <Grid2 xs={12} {...gridConfig as Grid2Props}>
         {isDialogMode(mode) && mode !== 'commandDialogForm' /* Cmd Title + actions is already shown in CommandDialog */ && nestingLevel === 1 && <Grid2 xs={12}>
@@ -272,18 +276,23 @@ export default function ObjectFieldTemplate<
         </Grid2>
       </Grid2>}
     </Grid2>
-    {(isDialogMode(mode) || nestingLevel > 1) && <BottomActions sx={{padding: nestingLevel === 1 ? `0 ${theme.spacing(2)}` : 0}} uiOptions={uiOptions}
-                    defaultService={props.formContext!.defaultService} jexlCtx={jexlCtx} additionalRightButtons={
-      isWriteMode(mode) && canExpand<T, S, F>(props.schema, props.uiSchema, props.formData) ? [
-        <AddButton
-          className='object-property-expand'
-          key={'object_field_' + props.idSchema.$id + '_object_property_expand'}
-          onClick={props.onAddClick(props.schema)}
-          disabled={props.disabled || props.readonly}
-          uiSchema={props.uiSchema}
-          registry={props.registry}
-        />
-      ] : undefined
+    {(isDialogMode(mode) || nestingLevel > 1) && <BottomActions
+      sx={{padding: nestingLevel === 1 ? `0 ${theme.spacing(2)}` : 0}}
+      uiOptions={uiOptions}
+      containerInfo={nestingLevel === 1 ? {name: fqcn, type: "mixed"} : undefined}
+      defaultService={props.formContext!.defaultService}
+      jexlCtx={jexlCtx}
+      additionalRightButtons={
+        isWriteMode(mode) && canExpand<T, S, F>(props.schema, props.uiSchema, props.formData) ? [
+          <AddButton
+            className='object-property-expand'
+            key={'object_field_' + props.idSchema.$id + '_object_property_expand'}
+            onClick={props.onAddClick(props.schema)}
+            disabled={props.disabled || props.readonly}
+            uiSchema={props.uiSchema}
+            registry={props.registry}
+          />
+        ] : undefined
     }/>}
   </>)
 }

--- a/packages/fe/src/app/components/core/form/types/action.ts
+++ b/packages/fe/src/app/components/core/form/types/action.ts
@@ -43,3 +43,9 @@ export type ActionConfig = LinkAction | CommandAction | RulesAction;
 
 export type TableActionConfig = (Omit<Omit<LinkAction, 'position'>, 'button'> | Omit<Omit<CommandAction, 'position'>, 'button'> | Omit<Omit<RulesAction, 'position'>, 'button'>) & {button: Partial<ButtonConfig>};
 
+export interface ActionContainerInfo {
+  // Name can be a page name (type: page), information type name (type: view), command name (type: command)
+  // or in case of "mixed" it is either an information type or command name, so both config registries have to be checked
+  name: string;
+  type: 'page' | 'view' | 'command' | 'mixed'
+}

--- a/packages/play/src/app/components/core/PlayTableView.tsx
+++ b/packages/play/src/app/components/core/PlayTableView.tsx
@@ -62,6 +62,7 @@ import {PageRegistry} from "@frontend/app/pages";
 import {PageMode} from "@cody-play/app/pages/PlayStandardPage";
 import {showTitle} from "@frontend/util/schema/show-title";
 import {informationTitle} from "@frontend/util/information/titelize";
+import {ActionContainerInfo} from "@frontend/app/components/core/form/types/action";
 
 const PlayTableView = (params: any, informationInfo: PlayInformationRuntimeInfo, pageMode: PageMode, hiddenView = false, uiSchemaOverride?: UiSchema, injectedInitialValues?: any) => {
   if(!isQueryableStateListDescription(informationInfo.desc) && !isQueryableListDescription(informationInfo.desc) && !isQueryableNotStoredStateListDescription(informationInfo.desc)) {
@@ -128,6 +129,11 @@ const PlayTableView = (params: any, informationInfo: PlayInformationRuntimeInfo,
     return <></>;
   }
 
+  const containerInfo: ActionContainerInfo = {
+    name: informationInfo.desc.name,
+    type: "view"
+  }
+
   return (
     <Box component="div">
       <Grid2 container={true}>
@@ -141,7 +147,11 @@ const PlayTableView = (params: any, informationInfo: PlayInformationRuntimeInfo,
             {informationTitle(informationInfo, uiSchema)}
           </Typography>}
         </Grid2>
-        <TopRightActions uiOptions={uiOptions} defaultService={normalizedDefaultService} jexlCtx={jexlCtx} />
+        <TopRightActions uiOptions={uiOptions}
+                         containerInfo={containerInfo}
+                         defaultService={normalizedDefaultService}
+                         jexlCtx={jexlCtx}
+        />
       </Grid2>
       {query.isLoading && <CircularProgress />}
       {query.isSuccess && (
@@ -164,7 +174,11 @@ const PlayTableView = (params: any, informationInfo: PlayInformationRuntimeInfo,
           }}
         />
       )}
-      <BottomActions uiOptions={uiOptions} defaultService={normalizedDefaultService} jexlCtx={jexlCtx} sx={{marginTop: theme.spacing(2)}} />
+      <BottomActions uiOptions={uiOptions}
+                     containerInfo={containerInfo}
+                     defaultService={normalizedDefaultService}
+                     jexlCtx={jexlCtx}
+                     sx={{marginTop: theme.spacing(2)}} />
     </Box>
   );
 };

--- a/packages/play/src/app/pages/PlayDialogPage.tsx
+++ b/packages/play/src/app/pages/PlayDialogPage.tsx
@@ -20,6 +20,7 @@ import Grid2 from "@mui/material/Unstable_Grid2";
 import TopRightActions from "@frontend/app/components/core/actions/TopRightActions";
 import BottomActions from "@frontend/app/components/core/actions/BottomActions";
 import {parseActionsFromPageCommands} from "@frontend/app/components/core/form/types/parse-actions";
+import {ActionContainerInfo} from "@frontend/app/components/core/form/types/action";
 
 interface OwnProps {
   page: string;
@@ -66,6 +67,11 @@ const PlayDialogPage = (props: PlayDialogPageProps) => {
     navigate(generatePageLink(mainPage, routeParams));
   };
 
+  const containerInfo: ActionContainerInfo = {
+    name: page.name,
+    type: "page"
+  }
+
   return <>
       <PlayStandardPage page={mainPage.name} />
       <Dialog open={true} fullWidth={true} maxWidth={'lg'} onClose={handleClose} sx={{"& .MuiDialog-paper": {minHeight: "50%"}}}>
@@ -75,7 +81,11 @@ const PlayDialogPage = (props: PlayDialogPageProps) => {
               {getPageTitle(page as unknown as PageDefinition)}
             </Grid2>
             {topRightActions.length
-              ? <TopRightActions actions={topRightActions}  uiOptions={{}} defaultService={defaultService} jexlCtx={jexlCtx} />
+              ? <TopRightActions actions={topRightActions}
+                                 containerInfo={containerInfo}
+                                 uiOptions={{}}
+                                 defaultService={defaultService}
+                                 jexlCtx={jexlCtx} />
               : <Grid2 xs
                        display="flex"
                        direction="column"
@@ -94,7 +104,12 @@ const PlayDialogPage = (props: PlayDialogPageProps) => {
         <DialogContent>
           <PlayStandardPage page={page.name} mode="dialog" />
         </DialogContent>
-        {bottomActions.length > 0 && <BottomActions sx={{padding: theme.spacing(3)}} actions={bottomActions} uiOptions={{}} defaultService={defaultService} jexlCtx={jexlCtx} />}
+        {bottomActions.length > 0 && <BottomActions sx={{padding: theme.spacing(3)}}
+                                                    actions={bottomActions}
+                                                    containerInfo={containerInfo}
+                                                    uiOptions={{}}
+                                                    defaultService={defaultService}
+                                                    jexlCtx={jexlCtx} />}
       </Dialog>
     </>
 };

--- a/packages/play/src/app/pages/PlayRightDrawerPage.tsx
+++ b/packages/play/src/app/pages/PlayRightDrawerPage.tsx
@@ -21,6 +21,7 @@ import Grid2 from "@mui/material/Unstable_Grid2";
 import TopRightActions from "@frontend/app/components/core/actions/TopRightActions";
 import BottomActions from "@frontend/app/components/core/actions/BottomActions";
 import {parseActionsFromPageCommands} from "@frontend/app/components/core/form/types/parse-actions";
+import {ActionContainerInfo} from "@frontend/app/components/core/form/types/action";
 
 interface OwnProps {
   page: string;
@@ -71,6 +72,11 @@ const PlayRightDrawerPage = (props: PlayRightDrawerPageProps) => {
     navigate(generatePageLink(mainPage, routeParams));
   };
 
+  const containerInfo: ActionContainerInfo = {
+    name: page.name,
+    type: "page"
+  }
+
   return <>
     <PlayStandardPage page={mainPage.name} drawerWidth={drawerWidth} />
     <Drawer anchor="right"
@@ -89,7 +95,11 @@ const PlayRightDrawerPage = (props: PlayRightDrawerPageProps) => {
             {getPageTitle(page as unknown as PageDefinition)}
           </Grid2>
           {topRightActions.length
-            ? <TopRightActions actions={topRightActions}  uiOptions={{}} defaultService={defaultService} jexlCtx={jexlCtx} />
+            ? <TopRightActions actions={topRightActions}
+                               containerInfo={containerInfo}
+                               uiOptions={{}}
+                               defaultService={defaultService}
+                               jexlCtx={jexlCtx} />
             : <Grid2 xs
                      display="flex"
                      direction="column"
@@ -106,7 +116,12 @@ const PlayRightDrawerPage = (props: PlayRightDrawerPageProps) => {
         </Grid2>
       </DialogTitle>
       <DialogContent><PlayStandardPage page={page.name} mode="drawer" /></DialogContent>
-      {bottomActions.length > 0 && <BottomActions actions={bottomActions} uiOptions={{}} defaultService={defaultService} jexlCtx={jexlCtx} sx={{padding: theme.spacing(3)}} />}
+      {bottomActions.length > 0 && <BottomActions actions={bottomActions}
+                                                  containerInfo={containerInfo}
+                                                  uiOptions={{}}
+                                                  defaultService={defaultService}
+                                                  jexlCtx={jexlCtx}
+                                                  sx={{padding: theme.spacing(3)}} />}
     </Drawer>
   </>
 };

--- a/packages/play/src/app/pages/PlayStandardPage.tsx
+++ b/packages/play/src/app/pages/PlayStandardPage.tsx
@@ -33,7 +33,7 @@ import {useTranslation} from "react-i18next";
 import BottomActions from "@frontend/app/components/core/actions/BottomActions";
 import {FormJexlContext} from "@frontend/app/components/core/form/types/form-jexl-context";
 import {useGlobalStore} from "@frontend/hooks/use-global-store";
-import {Action} from "@frontend/app/components/core/form/types/action";
+import {Action, ActionContainerInfo} from "@frontend/app/components/core/form/types/action";
 import {useEnv} from "@frontend/hooks/use-env";
 import ActionButton from "@frontend/app/components/core/ActionButton";
 import TopRightActions from "@frontend/app/components/core/actions/TopRightActions";
@@ -192,6 +192,11 @@ export const PlayStandardPage = (props: Props) => {
     className: "CodyStandardPage-root"
   };
 
+  const containerInfo: ActionContainerInfo = {
+    name: page.name,
+    type: "page"
+  }
+
   return <Grid2 {...{...defaultContainerProps, ...page.props?.container, sx: {...defaultContainerProps.sx, ...page.props?.container?.sx}}}>
     {config.layout === 'task-based-ui'
       && pageMode === "standard"
@@ -199,7 +204,11 @@ export const PlayStandardPage = (props: Props) => {
         <Grid2 xs={12} sx={headerGridSx}><PlayBreadcrumbs /></Grid2>
         <Grid2 xs sx={headerGridSx}>
           <Typography variant="h1" className="CodyPageTitle-root">{getPageTitle(page as unknown as PageDefinition)}</Typography></Grid2>
-        <TopRightActions actions={topActions} uiOptions={{}} defaultService={defaultService} jexlCtx={jexlCtx} />
+        <TopRightActions actions={topActions}
+                         containerInfo={containerInfo}
+                         uiOptions={{}}
+                         defaultService={defaultService}
+                         jexlCtx={jexlCtx} />
       </>}
     {topBar}
     <Grid2 xs={12} sx={{padding: 0}} />
@@ -221,7 +230,13 @@ export const PlayStandardPage = (props: Props) => {
       bottom: 0,
       zIndex: theme.zIndex.appBar,
     }}>
-      <BottomActions uiOptions={{}} defaultService={defaultService} jexlCtx={jexlCtx} actions={bottomActions} sx={{padding: `${theme.spacing(3)} ${theme.spacing(4)}`}} />
+      <BottomActions uiOptions={{}}
+                     containerInfo={containerInfo}
+                     defaultService={defaultService}
+                     jexlCtx={jexlCtx}
+                     actions={bottomActions}
+                     sx={{padding: `${theme.spacing(3)} ${theme.spacing(4)}`}}
+      />
     </Box>}
   </Grid2>
 }


### PR DESCRIPTION
Please note: 

The container info is optional, as it is mainly useful in the Cody Play environment in combination with the live edit mode.
The PR ensures that container info is given for all button drag & drop scenarios in Cody Play.

So to activate drag&drop this check is recommended:

```
// e.g. insight BottomActions.tsx
const env = useEnv();
// this hook does not exist yet
const [liveEditMode] = useLiveEditMode();

const isDragDropEnabled = liveEditMode && env.UI_ENV === 'play' && props.containerInfo;
```

Via container info you can easily access the appropriate section in the CodyPlayConfig:

## ContainerInfo.type = "page"

```
const {config, dispatch} = useContext(configStore);

if(props.containerInfo.type === "page") {
  const pageDefinition = config.pages[props.containerInfo.name];
}
```

## ContainerInfo.type = "view"

```
const {config, dispatch} = useContext(configStore);

if(props.containerInfo.type === "view") {
  const informationRuntimeInfo = config.types[props.containerInfo.name];
}
```

## ContainerInfo.type = "command"

```
const {config, dispatch} = useContext(configStore);

if(props.containerInfo.type === "command") {
  const commandRuntimeInfo = config.commands[props.containerInfo.name];
}
```

## ContainerInfo.type = "mixed"

```
const {config, dispatch} = useContext(configStore);

if(props.containerInfo.type === "command") {
  const commandOrInfoRuntimeInfo = config.commands[props.containerInfo.name] || config.types[props.containerInfo.name];
}
```
