### PR TITLE
fix: do not convert item names in play

### DIFF
--- a/packages/cody/src/lib/hooks/utils/ui/normalize-ui-metadata.ts
+++ b/packages/cody/src/lib/hooks/utils/ui/normalize-ui-metadata.ts
@@ -1,7 +1,7 @@
 import {RawUiMetadata, UiMetadata} from "@cody-engine/cody/hooks/utils/ui/types";
 import {names} from "@event-engine/messaging/helpers";
 
-export const normalizeUiMetadata = (meta: RawUiMetadata): UiMetadata => {
+export const normalizeUiMetadata = (meta: RawUiMetadata, normalizeIconNames = true): UiMetadata => {
   if(meta && meta.tab) {
 
     if(typeof meta.tab.hidden === "boolean") {
@@ -27,13 +27,13 @@ export const normalizeUiMetadata = (meta: RawUiMetadata): UiMetadata => {
       delete meta.tab["style:expr"];
     }
 
-    if(meta.tab.icon) {
+    if(normalizeIconNames && meta.tab.icon) {
       meta.tab.icon = names(meta.tab.icon).className;
     }
   }
 
   if(meta && meta.sidebar) {
-    if(meta.sidebar.icon) {
+    if(normalizeIconNames && meta.sidebar.icon) {
       meta.sidebar.icon = names(meta.sidebar.icon).className;
     }
 

--- a/packages/play/src/infrastructure/cody/hooks/on-document.ts
+++ b/packages/play/src/infrastructure/cody/hooks/on-document.ts
@@ -41,6 +41,7 @@ import {normalizeServerUiSchema} from "@frontend/util/schema/normalize-ui-schema
 import {camelCaseToTitle} from "@cody-play/infrastructure/utils/string";
 import {playRenameFQCN} from "@cody-play/infrastructure/vibe-cody/utils/play-rename-f-q-c-n";
 import {toSingularItemName} from "@event-engine/infrastructure/nlp/to-singular";
+import shortUUID from "short-uuid";
 
 export const onDocument = async (vo: Node, dispatch: PlayConfigDispatch, ctx: ElementEditedContext, config: CodyPlayConfig): Promise<CodyResponse> => {
   try {
@@ -197,6 +198,8 @@ const getInlineItemDesc = (vo: Node, voName: string, voMeta: PlayValueObjectMeta
 
   return {
     ...playGetProophBoardInfoFromDescription(desc),
+    // assign a unique _pbCardId to avoid sync issues with list VO card
+    _pbCardId: shortUUID.generate().toString(),
     isList: false,
     isQueryable: desc.isQueryable,
     name: playRenameFQCN(voName, itemLabel),

--- a/packages/play/src/infrastructure/cody/ui/play-ui-metadata.ts
+++ b/packages/play/src/infrastructure/cody/ui/play-ui-metadata.ts
@@ -1,11 +1,8 @@
 import {CodyResponse, Node} from "@proophboard/cody-types";
 import {ElementEditedContext} from "@cody-play/infrastructure/cody/cody-message-server";
 import {RawUiMetadata, UiMetadata} from "@cody-engine/cody/hooks/utils/ui/types";
-import {names} from "@event-engine/messaging/helpers";
 import {playParseJsonMetadata} from "@cody-play/infrastructure/cody/metadata/play-parse-json-metadata";
 import {playIsCodyError} from "@cody-play/infrastructure/cody/error-handling/with-error-check";
-import {playAllowedRoles} from "@cody-play/infrastructure/role/play-allowed-roles";
-import {playConvertToRoleCheck} from "@cody-play/infrastructure/role/play-convert-to-role-check";
 import {normalizeUiMetadata} from "@cody-engine/cody/hooks/utils/ui/normalize-ui-metadata";
 
 export type PlayUiMetadata = UiMetadata & {
@@ -21,5 +18,5 @@ export const playUiMetadata = (ui: Node, ctx: ElementEditedContext): PlayUiMetad
 
   const metadata = playIsCodyError(meta)? {} : meta;
 
-  return normalizeUiMetadata(metadata) as PlayUiMetadata;
+  return normalizeUiMetadata(metadata, false) as PlayUiMetadata;
 }

--- a/packages/play/src/infrastructure/vibe-cody/button-instructions/change-button-icon.tsx
+++ b/packages/play/src/infrastructure/vibe-cody/button-instructions/change-button-icon.tsx
@@ -5,6 +5,7 @@ import {playIsCodyError} from "@cody-play/infrastructure/cody/error-handling/wit
 import MdiIcon from "@cody-play/app/components/core/MdiIcon";
 import {HeartOutline} from "mdi-material-ui";
 import {getIconNameFromSearchStr, matchIcons} from "@cody-play/infrastructure/vibe-cody/utils/icons/mdi-icons";
+import {kebabCase} from "lodash";
 
 const makeChangeButtonIconInstruction = (icon: string): Instruction => {
   const TEXT = `Use icon ${icon}`;
@@ -20,7 +21,7 @@ const makeChangeButtonIconInstruction = (icon: string): Instruction => {
       const success = await setButtonProperty(
         ctx.focusedElement! as FocusedButton,
         'icon',
-        icon,
+        kebabCase(icon),
         config,
         dispatch
       )

--- a/packages/play/src/infrastructure/vibe-cody/sidebar-instructions/change-sidebar-group-icon.tsx
+++ b/packages/play/src/infrastructure/vibe-cody/sidebar-instructions/change-sidebar-group-icon.tsx
@@ -8,6 +8,7 @@ import {isTopLevelPage, PageDefinition} from "@frontend/app/pages/page-definitio
 import {getGroup} from "@cody-play/infrastructure/vibe-cody/sidebar-instructions/move-sidebar-item";
 import {getIconNameFromSearchStr, matchIcons} from "@cody-play/infrastructure/vibe-cody/utils/icons/mdi-icons";
 import {HeartOutline} from "mdi-material-ui";
+import {kebabCase} from "lodash";
 
 const makeChangeSidebarGroupIconInstruction = (icon: string): Instruction => {
   const TEXT = `Use icon ${icon}`;
@@ -38,7 +39,7 @@ const makeChangeSidebarGroupIconInstruction = (icon: string): Instruction => {
         const copy = cloneDeepJSON(p) as PlayTopLevelPage;
         const group = getGroup(copy);
         if (group) {
-          group.icon = icon;
+          group.icon = kebabCase(icon);
         }
 
         copy.sidebar.group = group;

--- a/packages/play/src/infrastructure/vibe-cody/sidebar-instructions/change-sidebar-item-icon.tsx
+++ b/packages/play/src/infrastructure/vibe-cody/sidebar-instructions/change-sidebar-item-icon.tsx
@@ -7,6 +7,7 @@ import {cloneDeepJSON} from "@frontend/util/clone-deep-json";
 import {PlayTopLevelPage} from "@cody-play/state/types";
 import {getEditedContextFromConfig} from "@cody-play/state/config-store";
 import {getIconNameFromSearchStr, matchIcons} from "@cody-play/infrastructure/vibe-cody/utils/icons/mdi-icons";
+import {kebabCase} from "lodash";
 
 const makeChangeSidebarIconInstruction = (icon: string): Instruction => {
   const TEXT = `Use icon ${icon}`;
@@ -41,7 +42,7 @@ const makeChangeSidebarIconInstruction = (icon: string): Instruction => {
 
       const pageCopy = cloneDeepJSON(page) as PlayTopLevelPage;
 
-      pageCopy.sidebar.icon = icon;
+      pageCopy.sidebar.icon = kebabCase(icon);
 
       dispatch({
         ctx: getEditedContextFromConfig(config),


### PR DESCRIPTION
Assign a unique _pbCardId to inline array item