### PR TITLE
Feature/play production server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ data/*
 
 # playshots
 packages/be/src/playconfig/playshot.ts
+packages/fe/src/playconfig/playshot.ts
 
 # Environment
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ data/*
 # docker env
 !env/docker/pgadmin/tmp/.gitkeep
 
+# playshots
+packages/be/src/playconfig/playshot.ts
+
 # Environment
 .env
 packages/fe/src/environments/environment.ts

--- a/packages/be/package.json
+++ b/packages/be/package.json
@@ -9,6 +9,7 @@
         "@event-engine/infrastructure": "file:packages/infrastructure",
         "@event-engine/messaging": "file:packages/messaging",
         "@event-engine/descriptions": "file:packages/descriptions",
+        "@cody-play/package": "file:packages/play",
         "express": "~4.18.1",
         "express-async-errors": "^3.1.1",
         "express-jwt": "^8.4.1",

--- a/packages/be/src/main.ts
+++ b/packages/be/src/main.ts
@@ -15,6 +15,7 @@ import {AuthService} from "@event-engine/infrastructure/auth-service/auth-servic
 import { expressjwt } from 'express-jwt';
 import { env } from '@server/environments/environment.current';
 import * as util from "node:util";
+import {bootstrapPlayBackend} from "@server/playconfig/bootstrap-play-backend";
 
 const host = process.env.HOST ?? 'localhost';
 const port = process.env.PORT ? Number(process.env.PORT) : 4100;
@@ -130,6 +131,8 @@ app.get('/api/health', (req, res) => {
 });
 
 app.use(errorHandler);
+
+bootstrapPlayBackend();
 
 app.listen(port, host, async () => {
   console.log(`[ ready ] http://${host}:${port}`);

--- a/packages/be/src/playconfig/be-play-config.ts
+++ b/packages/be/src/playconfig/be-play-config.ts
@@ -1,0 +1,53 @@
+import {
+  PlayAggregateRegistry, PlayApplyRulesRegistry,
+  PlayCommandHandlerRegistry,
+  PlayCommandRegistry, PlayEventPolicyRegistry,
+  PlayEventRegistry, PlayInformationRegistry, PlayQueryRegistry, PlayResolverRegistry,
+  PlaySchemaDefinitions, PlayServiceRegistry
+} from "@cody-play/package/state/types";
+import {PaletteOptions, SxProps} from "@mui/material";
+
+export interface BePlayConfig {
+  defaultService: string,
+  commands: PlayCommandRegistry,
+  commandHandlers: PlayCommandHandlerRegistry,
+  aggregates: PlayAggregateRegistry,
+  events: PlayEventRegistry,
+  eventReducers: PlayApplyRulesRegistry,
+  eventPolicies: PlayEventPolicyRegistry,
+  queries: PlayQueryRegistry,
+  resolvers: PlayResolverRegistry,
+  types: PlayInformationRegistry,
+  definitions: PlaySchemaDefinitions,
+  services: PlayServiceRegistry,
+}
+
+// Override MUI theme options to avoid compile errors of Cody Play Config
+declare module '@mui/material/styles' {
+  interface Theme {
+    commandForm: {
+      "styleOverrides": SxProps;
+    }
+    stateView: {
+      "styleOverrides": SxProps;
+    },
+    formAction: {
+      "styleOverrides": SxProps;
+    }
+  }
+  // allow configuration using `createTheme`
+  interface ThemeOptions {
+    darkPalette?: PaletteOptions,
+    lightPalette?: PaletteOptions,
+    vars?: Record<string, any>,
+    commandForm?: {
+      "styleOverrides": SxProps;
+    }
+    stateView?: {
+      "styleOverrides": SxProps;
+    },
+    formAction?: {
+      "styleOverrides": SxProps;
+    }
+  }
+}

--- a/packages/be/src/playconfig/bootstrap-play-backend.ts
+++ b/packages/be/src/playconfig/bootstrap-play-backend.ts
@@ -1,0 +1,286 @@
+import {commandHandlers} from "@server/command-handlers/index";
+import {makePureCommandHandler} from "@cody-play/package/infrastructure/commands/make-pure-command-handler";
+import {isAggregateCommandDescription} from "@event-engine/descriptions/descriptions";
+import {playshot} from "@server/playconfig/playshot";
+import {repositories} from "@server/repositories/index";
+import {AggregateRepository, ApplyFunction} from "@server/infrastructure/AggregateRepository";
+import {getConfiguredMultiModelStore} from "@server/infrastructure/configuredMultiModelStore";
+import {getConfiguredMessageBox} from "@server/infrastructure/configuredMessageBox";
+import {getExternalServiceOrThrow} from "@server/extensions/get-external-service";
+import {AuthService, SERVICE_NAME_AUTH_SERVICE} from "@event-engine/infrastructure/auth-service/auth-service";
+import {
+  INFORMATION_SERVICE_NAME,
+  InformationService
+} from "@event-engine/infrastructure/information-service/information-service";
+import {WRITE_MODEL_STREAM} from "@server/infrastructure/configuredEventStore";
+import {makeInformationFactory} from "@cody-play/infrastructure/information/make-information-factory";
+import {makeAggregateCommandHandler} from "@cody-play/infrastructure/commands/make-aggregate-command-handler";
+import {commands} from "@app/shared/commands";
+import {makeCommandFactory} from "@cody-play/infrastructure/commands/make-command-factory";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+import {PlayEventReducers, PlaySchemaDefinitions} from "@cody-play/state/types";
+import {makeEventReducer} from "@cody-play/infrastructure/events/make-event-reducer";
+import {events} from "@app/shared/events";
+import {makeEventFactory} from "@cody-play/infrastructure/events/make-event-factory";
+import {queries} from "@app/shared/queries";
+import {makeQueryFactory} from "@cody-play/queries/make-query-factory";
+import {queryResolvers} from "@server/query-resolvers/index";
+import {makeQueryResolver} from "@server/playconfig/utils/make-query-resolver";
+import definitions from "@app/shared/types/definitions";
+import {policies} from "@server/policies/index";
+import {makePolicy} from "@server/playconfig/utils/make-policy";
+import {types} from "@app/shared/types";
+import {services} from "@server/extensions/services";
+import {makePlayRulesServiceFactory} from "@cody-play/infrastructure/services/make-play-rules-service-factory";
+import {informationServiceFactory} from "@server/infrastructure/information-service/information-service-factory";
+import {names} from "@event-engine/messaging/helpers";
+
+export const bootstrapPlayBackend = () => {
+  registerTypes();
+  registerCommands();
+  bootstrapCommandHandlers();
+  registerEvents();
+  bootstrapPolicies();
+  registerQueries();
+  bootstrapQueryResolvers();
+  bootstrapServices();
+}
+
+const playDefinitionIdFromFQCN = (fqcn: string): string => {
+  return '/definitions/' + fqcn
+    .split(".")
+    .map(r => names(r).fileName)
+    .join("/");
+}
+
+const registerTypes = () => {
+  for (const typeName in playshot.types) {
+    const information = playshot.types[typeName];
+
+    if(types[typeName]) {
+      console.log(`Skipping play type "${typeName}". A custom type is configured.`);
+      continue;
+    }
+
+    types[typeName] = {
+      desc: information.desc,
+      schema: information.schema,
+      uiSchema: information.uiSchema,
+      factory: makeInformationFactory(information.factory)
+    };
+
+    (definitions as any)[playDefinitionIdFromFQCN(typeName)] = information.schema;
+
+    console.log(`Registered play type "${typeName}".`);
+  }
+}
+
+const registerCommands = () => {
+  for (const commandName in playshot.commands) {
+    if(commands[commandName]) {
+      console.log(`Skipping play command "${commandName}". A custom command is configured.`)
+      continue;
+    }
+
+    const command = playshot.commands[commandName];
+
+    commands[commandName] = {
+      desc: command.desc,
+      schema: command.schema,
+      uiSchema: command.uiSchema,
+      factory: makeCommandFactory(command, definitions as unknown as PlaySchemaDefinitions)
+    }
+
+    console.log(`Registered play command "${commandName}".`)
+  }
+}
+
+const registerEvents = () => {
+  for (const eventName in playshot.events) {
+    if(events[eventName]) {
+      console.log(`Skipping play event "${eventName}". A custom event is configured.`)
+      continue;
+    }
+
+    const event = playshot.events[eventName];
+
+    events[eventName] = {
+      desc: event.desc,
+      schema: event.schema,
+      factory: makeEventFactory(event, definitions as unknown as PlaySchemaDefinitions)
+    }
+
+    console.log(`Registered play event "${eventName}".`)
+  }
+}
+
+const registerQueries = () => {
+  for (const queryName in playshot.queries) {
+    if(queries[queryName]) {
+      console.log(`Skipping play query "${queryName}". A custom query is configured.`)
+      continue;
+    }
+
+    const query = playshot.queries[queryName];
+
+    queries[queryName] = {
+      desc: query.desc,
+      schema: query.schema,
+      factory: makeQueryFactory(query, definitions as unknown as PlaySchemaDefinitions)
+    }
+
+    console.log(`Registered play query "${queryName}".`)
+  }
+}
+
+const bootstrapCommandHandlers = () => {
+  const messageBox = getConfiguredMessageBox();
+  const store = getConfiguredMultiModelStore();
+  const authService = getExternalServiceOrThrow<AuthService>(SERVICE_NAME_AUTH_SERVICE, {});
+  const informationService = getExternalServiceOrThrow<InformationService>(INFORMATION_SERVICE_NAME, {});
+
+  for (const commandName in playshot.commandHandlers) {
+    const command = playshot.commands[commandName];
+
+    if(!command) {
+      console.warn(`Skipping play command handler. Command "${commandName}" cannot not be found in the playshot.`);
+      continue;
+    }
+
+    if(commandHandlers[commandName]) {
+      console.log(`Skipping play command handler for command "${commandName}". A custom handler is configured.`);
+      continue;
+    }
+
+    if(isAggregateCommandDescription(command.desc) && playshot.aggregates[command.desc.aggregateName]) {
+      const aggregate = playshot.aggregates[command.desc.aggregateName];
+
+      if(repositories[command.desc.aggregateName]) {
+        console.log(`Skipping play repository for aggregate "${command.desc.aggregateName}". A custom repository is configured.`)
+      } else {
+        const arState = playshot.types[aggregate.state];
+
+        if(!arState) {
+          throw new Error(`Cannot set up play aggregate handling for aggregate ${aggregate.name}, the aggregate state "${aggregate.state}" cannot be found in the types registry.`);
+        }
+
+        repositories[command.desc.aggregateName] = (): AggregateRepository<any> => {
+          return new AggregateRepository<any>(
+            store,
+            aggregate.stream || WRITE_MODEL_STREAM,
+            aggregate.collection,
+            aggregate.name,
+            aggregate.identifier,
+            makeEventReducers(playshot.eventReducers[aggregate.name] || [], playshot as CodyPlayConfig),
+            makeInformationFactory(arState.factory),
+            authService,
+            informationService,
+            messageBox
+          )
+        }
+
+        console.log(`Registered play aggregate repository for: ${command.desc.aggregateName}.`);
+      }
+
+      console.log(`Registered play aggregate command handler for: ${commandName}.`);
+
+      commandHandlers[commandName] = makeAggregateCommandHandler(
+        playshot.commandHandlers[commandName],
+        playshot.events,
+        definitions as unknown as PlaySchemaDefinitions,
+        aggregate,
+        false
+      )
+
+    } else {
+      console.log(`Registered play pure command handler for: ${commandName}.`);
+
+      commandHandlers[commandName] = makePureCommandHandler(
+        playshot.commandHandlers[commandName],
+        playshot.events,
+        definitions as unknown as PlaySchemaDefinitions,
+        command.desc,
+        false
+      )
+    }
+  }
+}
+
+const makeEventReducers = (eventReducers: PlayEventReducers, config: CodyPlayConfig): {[eventName: string]: ApplyFunction<any>} => {
+  const mappedReducers: {[eventName: string]: ApplyFunction<any>} = {};
+
+  for (const eventName in eventReducers) {
+    mappedReducers[eventName] = makeEventReducer(eventReducers[eventName], config);
+  }
+
+  return mappedReducers;
+}
+
+const bootstrapPolicies = () => {
+  for (const eventName in playshot.eventPolicies) {
+    for (let policyName in playshot.eventPolicies[eventName]) {
+      const policy = playshot.eventPolicies[eventName][policyName];
+
+      if(!policyName.includes('.')) {
+        policyName = `${playshot.defaultService}.${policyName}`
+      }
+
+      if(!policies[eventName]) {
+        policies[eventName] = {}
+      }
+
+      if(policies[eventName][policyName]) {
+        console.log(`Skipping play policy "${policyName}" for event "${eventName}". A custom policy is configured.`);
+        continue;
+      }
+
+      policies[eventName][policyName] = {
+        policy: makePolicy(policy, playshot),
+        desc: policy
+      }
+
+      console.log(`Registered play policy "${policyName}" for event "${eventName}".`)
+    }
+  }
+}
+
+const bootstrapQueryResolvers = () => {
+  for (const queryName in playshot.resolvers) {
+    const query = playshot.queries[queryName];
+
+    if(!query) {
+      console.warn(`Skipping play resolver for query "${queryName}". Query cannot be found in the playshot.`)
+    }
+
+    const information = playshot.types[query.desc.returnType];
+
+    if(!information) {
+      console.warn(`Skipping play resolver for query "${queryName}". Query return type "${query.desc.returnType}" cannot be found in the playshot types.`);
+    }
+
+    if(queryResolvers[queryName]) {
+      console.log(`Skipping play query resolver for "${queryName}". A custom resolver is configured.`);
+      continue;
+    }
+
+    const resolveConfig = playshot.resolvers[queryName];
+
+    queryResolvers[queryName] = makeQueryResolver(query, resolveConfig, information, playshot);
+
+    console.log(`Registered play query resolver for: ${queryName}.`);
+  }
+}
+
+const bootstrapServices = () => {
+  for (const serviceName in playshot.services) {
+    if(services[serviceName]) {
+      console.log(`Skipping play service "${serviceName}". A custom service is configured.`);
+      continue;
+    }
+
+    services[serviceName] = makePlayRulesServiceFactory(serviceName, playshot.services[serviceName], informationServiceFactory);
+
+    console.log(`Registered play service "${serviceName}".`);
+  }
+}
+

--- a/packages/be/src/playconfig/playshot.ts.cetmpl
+++ b/packages/be/src/playconfig/playshot.ts.cetmpl
@@ -1,0 +1,16 @@
+import {BePlayConfig} from "@server/playconfig/be-play-config";
+
+export const playshot = {
+  "defaultService": "App",
+  "commands": {},
+  "commandHandlers": {},
+  "aggregates": {},
+  "events": {},
+  "eventReducers": {},
+  "queries": {},
+  "resolvers": {},
+  "types": {},
+  "definitions": {},
+  "eventPolicies": {},
+  "services": {}
+} as unknown as BePlayConfig;

--- a/packages/be/src/playconfig/utils/make-policy.ts
+++ b/packages/be/src/playconfig/utils/make-policy.ts
@@ -1,0 +1,24 @@
+import {Policy} from "@event-engine/infrastructure/PolicyRegistry";
+import {getConfiguredMessageBox} from "@server/infrastructure/configuredMessageBox";
+import {Event} from "@event-engine/messaging/event";
+import {makeAsyncExecutable} from "@cody-play/infrastructure/rule-engine/make-executable";
+import {BePlayConfig} from "@server/playconfig/be-play-config";
+import {PlayEventPolicyDescription} from "@cody-play/state/types";
+import definitions from "@app/shared/types/definitions";
+
+const messageBox = getConfiguredMessageBox();
+
+export const makePolicy = (policy: PlayEventPolicyDescription, playConfig: BePlayConfig): Policy => {
+    return async (event: Event, deps: any): Promise<void> => {
+      const ctx = {event: event.payload, meta: event.meta, eventCreatedAt: event.createdAt, ...deps, commandRegistry: playConfig.commands, schemaDefinitions: definitions};
+
+      const exe = makeAsyncExecutable(policy.rules);
+      const result = await exe(ctx);
+
+      if(result['commands']) {
+        for (const command of result['commands']) {
+          messageBox.dispatch(command.name, command.payload, command.meta).catch((e: any) => console.error(e));
+        }
+      }
+    }
+}

--- a/packages/be/src/playconfig/utils/make-query-resolver.ts
+++ b/packages/be/src/playconfig/utils/make-query-resolver.ts
@@ -1,0 +1,27 @@
+import {PlayInformationRuntimeInfo, PlayQueryRuntimeInfo, PlaySchemaDefinitions} from "@cody-play/state/types";
+import {ResolveConfig} from "@cody-play/infrastructure/cody/vo/play-vo-metadata";
+import {QueryResolverWithDependencies} from "@event-engine/messaging/query";
+import {User} from "@app/shared/types/core/user/user";
+import {makeQueryFactory} from "@cody-play/queries/make-query-factory";
+import {determineQueryPayload} from "@app/shared/utils/determine-query-payload";
+import {getConfiguredDocumentStore} from "@server/infrastructure/configuredDocumentStore";
+import {getExternalServiceOrThrow} from "@server/extensions/get-external-service";
+import {
+  INFORMATION_SERVICE_NAME,
+  InformationService
+} from "@event-engine/infrastructure/information-service/information-service";
+import {resolve, ResolvedCtx} from "@cody-play/queries/resolve";
+import {BePlayConfig} from "@server/playconfig/be-play-config";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+
+
+export const makeQueryResolver = (queryInfo: PlayQueryRuntimeInfo, resolveConfig: ResolveConfig, informationInfo: PlayInformationRuntimeInfo, playConfig: BePlayConfig): QueryResolverWithDependencies => {
+  return async (query, dependencies) => {
+    const ds = getConfiguredDocumentStore();
+    const infoService = getExternalServiceOrThrow<InformationService>(INFORMATION_SERVICE_NAME, {});
+
+    const resolvedCtx: ResolvedCtx = {...dependencies, query: query.payload, meta: query.meta};
+
+    return resolve(ds, infoService, resolveConfig, informationInfo, queryInfo, resolvedCtx, playConfig as CodyPlayConfig, query.meta.user as User, false);
+  }
+}

--- a/packages/be/tsconfig.json
+++ b/packages/be/tsconfig.json
@@ -11,6 +11,7 @@
     }
   ],
   "compilerOptions": {
+    "jsx": "react-jsx",
     "esModuleInterop": true
   }
 }

--- a/packages/fe/src/app/components/core/commands/make-standard-command-component.tsx
+++ b/packages/fe/src/app/components/core/commands/make-standard-command-component.tsx
@@ -1,0 +1,102 @@
+import {CommandRuntimeInfo} from "@event-engine/messaging/command";
+import CommandButton, {WithCommandButtonProps} from "@frontend/app/components/core/CommandButton";
+import {useState} from "react";
+import {useUser} from "@frontend/hooks/use-user";
+import {useParams} from "react-router-dom";
+import {usePageData} from "@frontend/hooks/use-page-data";
+import {useGlobalStore} from "@frontend/hooks/use-global-store";
+import {merge} from "lodash/fp";
+import {getInitialValues} from "@frontend/util/command-form/get-initial-values";
+import DirectCommandButton from "@frontend/app/components/core/DirectCommandButton";
+import ConnectedCommandButton from "@frontend/app/components/core/ConnectedCommandButton";
+import CommandDialog from "@frontend/app/components/core/CommandDialog";
+import * as React from "react";
+import {AxiosResponse} from "axios";
+import {Api} from "@frontend/api";
+
+interface OwnProps {
+  initialValues?: { [prop: string]: unknown };
+  onDialogOpen?: () => void;
+  onDialogClose?: () => void;
+}
+
+type StandardCommandProps = OwnProps & WithCommandButtonProps;
+
+export const makeStandardCommandComponent = (command: CommandRuntimeInfo) => {
+
+  const triggerCommand = (params: any): Promise<AxiosResponse> => {
+    return Api.executeCommand(command.desc.name, params);
+  }
+
+  return (props: StandardCommandProps) => {
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [user] = useUser();
+    const routeParams = useParams();
+    const [page] = usePageData();
+    const [store] = useGlobalStore();
+
+    const uiSchema = merge(command.uiSchema, props.uiSchemaOverride);
+
+    const modifiedRuntimeInfo = {
+      ...command,
+      uiSchema,
+    };
+
+    const handleOpenDialog = () => {
+      setDialogOpen(true);
+      if (props.onDialogOpen) {
+        props.onDialogOpen();
+      }
+    };
+    const handleCloseDialog = () => {
+      setDialogOpen(false);
+      if (props.onDialogClose) {
+        props.onDialogClose();
+      }
+    };
+
+    const initialValues =
+      props.initialValues ||
+      getInitialValues(modifiedRuntimeInfo, { user, routeParams, page, store });
+
+    if (props.directSubmit) {
+      return (
+        <DirectCommandButton
+          command={modifiedRuntimeInfo}
+          commandFn={triggerCommand}
+          data={initialValues || {}}
+          buttonProps={props.buttonProps}
+        />
+      );
+    }
+
+    if (props.connectTo) {
+      return (
+        <ConnectedCommandButton
+          command={modifiedRuntimeInfo}
+          commandFn={triggerCommand}
+          connectTo={props.connectTo}
+          forceSchema={props.forceSchema}
+          buttonProps={props.buttonProps}
+        />
+      );
+    }
+
+    return (
+      <>
+        <CommandButton
+          command={modifiedRuntimeInfo}
+          onClick={handleOpenDialog}
+          { ...props.buttonProps }
+        />
+        <CommandDialog
+          open={dialogOpen}
+          onClose={handleCloseDialog}
+          commandDialogCommand={modifiedRuntimeInfo}
+          commandFn={triggerCommand}
+          initialValues={initialValues}
+        />
+      </>
+    );
+  }
+}

--- a/packages/fe/src/app/components/core/form/widgets/html/DynamicHtmlWidget.tsx
+++ b/packages/fe/src/app/components/core/form/widgets/html/DynamicHtmlWidget.tsx
@@ -69,6 +69,8 @@ const DynamicHtmlWidget = (props: DynamicHtmlWidgetProps) => {
   let config = props.config;
 
   if(query.isSuccess) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     jexlCtx.result = query.data;
 
     config = normalizeUiSchema(config, jexlCtx, env);

--- a/packages/fe/src/app/components/core/views/make-mdi-icon.tsx
+++ b/packages/fe/src/app/components/core/views/make-mdi-icon.tsx
@@ -1,0 +1,7 @@
+import MdiIcon from "@cody-play/app/components/core/MdiIcon";
+
+export const makeMdiIcon = (name: string) => {
+  return () => {
+    return MdiIcon({icon: name});
+  }
+}

--- a/packages/fe/src/app/components/core/views/make-standard-list-view-component.tsx
+++ b/packages/fe/src/app/components/core/views/make-standard-list-view-component.tsx
@@ -1,0 +1,278 @@
+import {ValueObjectRuntimeInfo} from "@event-engine/messaging/value-object";
+import {ViewRuntimeConfig} from "@frontend/app/components/core/views/view-runtime-config";
+import {useEnv} from "@frontend/hooks/use-env";
+import {Box, CircularProgress, Typography, useTheme} from "@mui/material";
+import {useUser} from "@frontend/hooks/use-user";
+import {usePageData} from "@frontend/hooks/use-page-data";
+import {useGlobalStore} from "@frontend/hooks/use-global-store";
+import {names} from "@event-engine/messaging/helpers";
+import {merge} from "lodash/fp";
+import {get} from "lodash";
+import {useApiQuery} from "@frontend/queries/use-api-query";
+import {normalizeUiSchema} from "@frontend/util/schema/normalize-ui-schema";
+import {getUiOptions, UiSchema} from "@rjsf/utils";
+import {TableUiSchema} from "@cody-engine/cody/hooks/utils/value-object/types";
+import {getTableDensity, getTablePageSizeConfig} from "@cody-play/infrastructure/ui-table/utils";
+import {
+  isQueryableListDescription,
+  isQueryableNotStoredStateListDescription,
+  isQueryableStateListDescription, QueryableListDescription
+} from "@event-engine/descriptions/descriptions";
+import jexl from "@app/shared/jexl/get-configured-jexl";
+import React, {useEffect} from "react";
+import {triggerSideBarAnchorsRendered} from "@frontend/util/sidebar/trigger-sidebar-anchors-rendered";
+import {registryIdToDataReference} from "@app/shared/utils/registry-id-to-data-reference";
+import {DataGrid, GridColDef, GridToolbar} from "@mui/x-data-grid";
+import {compileTableColumns} from "@cody-play/app/components/core/PlayTableView";
+import {
+  PlayInformationRegistry,
+  PlayInformationRuntimeInfo,
+  PlayPageRegistry,
+  PlayQueryRegistry, PlaySchemaDefinitions
+} from "@cody-play/state/types";
+import {queries} from "@app/shared/queries";
+import {pages} from "@frontend/app/pages";
+import {types} from "@app/shared/types";
+import definitions from "@app/shared/types/definitions";
+import Grid2 from "@mui/material/Unstable_Grid2";
+import {showTitle} from "@frontend/util/schema/show-title";
+import {informationTitle} from "@frontend/util/information/titelize";
+import TopRightActions from "@frontend/app/components/core/actions/TopRightActions";
+import NoRowsOverlay from "@frontend/app/components/core/table/NoRowsOverlay";
+import BottomActions from "@frontend/app/components/core/actions/BottomActions";
+import StateView from "@frontend/app/components/core/StateView";
+import {cloneDeepJSON} from "@frontend/util/clone-deep-json";
+
+export const makeStandardListViewComponent = (information: ValueObjectRuntimeInfo) => {
+  if (
+    !isQueryableStateListDescription(information.desc) &&
+    !isQueryableListDescription(information.desc) &&
+    !isQueryableNotStoredStateListDescription(information.desc)
+  ) {
+    throw new Error(
+      `Play table view can only be used to show queriable state list information, but "${information.desc.name}" is not of this information type.`
+    );
+  }
+
+
+  return (params: object & {hidden?: boolean}, config: ViewRuntimeConfig) => {
+    const env = useEnv();
+    const theme = useTheme();
+    const [user] = useUser();
+    const [page, addQueryResult] = usePageData();
+    const [store, setStore] = useGlobalStore();
+    const normalizedDefaultService = names(env.DEFAULT_SERVICE).className;
+
+    const mergedUiSchema = merge(
+      information.uiSchema || {},
+      config.uiSchemaOverride || {}
+    );
+    // Get items UI schema from original (not normalized) ui schema, so that expr tags can be evaluated in the context of each item
+    const itemsUiSchema = get(mergedUiSchema, 'ui:list.items', {});
+
+    // Prepare the main query
+    const queryParams = get(mergedUiSchema, 'ui:query', params);
+
+    const jexlQueryCtx = {
+      theme,
+      routeParams: params,
+      user,
+      page,
+      store,
+      data: {},
+    };
+
+    const query = useApiQuery(
+      (information.desc as QueryableListDescription).query,
+      normalizeUiSchema(queryParams, jexlQueryCtx, env),
+      {},
+      !config.loadState
+    );
+
+    const jexlCtx = {
+      theme,
+      routeParams: params,
+      user,
+      page,
+      store,
+      data: query.isSuccess ? query.data : {},
+    };
+
+    const uiSchema: UiSchema & TableUiSchema = normalizeUiSchema(
+      mergedUiSchema,
+      jexlCtx,
+      env
+    );
+    const uiOptions = getUiOptions(uiSchema);
+
+    let isHidden = config.isHiddenView;
+
+    if (!config.isHiddenView && typeof uiSchema['ui:hidden'] !== 'undefined') {
+      if (typeof uiSchema['ui:hidden'] === 'string') {
+        isHidden = jexl.evalSync(uiSchema['ui:hidden'], jexlCtx);
+      } else {
+        isHidden = uiSchema['ui:hidden'];
+      }
+    }
+
+    const itemIdentifier =
+      isQueryableStateListDescription(information.desc) ||
+      isQueryableNotStoredStateListDescription(information.desc)
+        ? information.desc.itemIdentifier
+        : undefined;
+
+    useEffect(() => {
+      triggerSideBarAnchorsRendered();
+    }, [params]);
+
+    useEffect(() => {
+      addQueryResult(registryIdToDataReference(information.desc.name), query);
+    }, [params, query.dataUpdatedAt]);
+
+    if (isHidden) {
+      return <></>;
+    }
+
+    if (config.viewType === 'list') {
+      // Prepare infos for list view
+      const listGridProps = get(uiSchema, 'ui:list.ui:options.container.props', {});
+      const itemGridProps = normalizeUiSchema(
+        get(cloneDeepJSON(itemsUiSchema), 'ui:options.grid.props', { xs: 12 }),
+        jexlCtx,
+        env
+      );
+      const itemInfo =
+        types[(information.desc as QueryableListDescription).itemType];
+
+
+      return (
+        <Box component="div">
+          <Grid2 container={true}>
+            <Grid2 xs>
+              {showTitle(uiSchema) && (
+                <Typography
+                  variant="h2"
+                  className="sidebar-anchor"
+                  id={`component-${names(information.desc.name).fileName}`}
+                  sx={{ padding: (theme) => theme.spacing(4), paddingLeft: 0 }}
+                >
+                  {informationTitle(information, uiSchema)}
+                </Typography>
+              )}
+            </Grid2>
+            <TopRightActions
+              uiOptions={uiOptions}
+              defaultService={normalizedDefaultService}
+              jexlCtx={jexlCtx}
+            />
+          </Grid2>
+          {query.isLoading && <CircularProgress />}
+          {query.isSuccess && (
+            <Grid2
+              container={true}
+              className="CodyListView-grid"
+              {...listGridProps}
+            >
+              {Array.isArray(query.data) && query.data.map((item: any, itemIndex: number) => (
+                <Grid2 key={item[(itemIdentifier || `list-item-${itemIndex}`)]} {...itemGridProps}>
+                  <StateView
+                    mode={'listView'}
+                    description={{
+                      ...itemInfo,
+                      uiSchema: merge(itemInfo.uiSchema || {}, itemsUiSchema),
+                    }}
+                    state={item}
+                  />
+                </Grid2>
+              ))}
+            </Grid2>
+          )}
+          <BottomActions
+            uiOptions={uiOptions}
+            defaultService={normalizedDefaultService}
+            jexlCtx={jexlCtx}
+            sx={{ marginTop: theme.spacing(2) }}
+          />
+        </Box>
+      );
+    }
+
+    // Normalize table uiSchema
+    if (uiSchema['ui:table']) {
+      uiSchema.table = uiSchema['ui:table'];
+    }
+
+    const pageSizeConfig = getTablePageSizeConfig(uiSchema);
+    const density = getTableDensity(uiSchema);
+    const hideToolbar = !!uiSchema.table?.hideToolbar;
+    const checkboxSelection = !!uiSchema.table?.checkboxSelection;
+
+    const columns: GridColDef[] = compileTableColumns(
+      params,
+      information as unknown as PlayInformationRuntimeInfo,
+      uiSchema,
+      queries as unknown as PlayQueryRegistry,
+      pages as unknown as PlayPageRegistry,
+      user,
+      types as unknown as PlayInformationRegistry,
+      definitions as unknown as PlaySchemaDefinitions,
+      normalizedDefaultService
+    );
+
+    // Return default table view
+    return (
+      <Box component="div">
+        <Grid2 container={true}>
+          <Grid2 xs>
+            {showTitle(uiSchema) && (
+              <Typography
+                variant="h2"
+                className="sidebar-anchor"
+                sx={{ padding: (theme) => theme.spacing(4), paddingLeft: 0 }}
+                id={'component-app-my-projects'}
+              >
+                {informationTitle(information, uiSchema)}
+              </Typography>
+            )}
+          </Grid2>
+          <TopRightActions
+            uiOptions={uiOptions}
+            defaultService={normalizedDefaultService}
+            jexlCtx={jexlCtx}
+          />
+        </Grid2>
+        {query.isLoading && <CircularProgress />}
+        {query.isSuccess && (
+          <DataGrid
+            columns={columns}
+            rows={Array.isArray(query.data) ? query.data : []}
+            getRowId={(row) =>
+              itemIdentifier ? row[itemIdentifier] : JSON.stringify(row)
+            }
+            sx={{ width: '100%' }}
+            slots={{
+              toolbar: hideToolbar ? undefined : GridToolbar,
+              noRowsOverlay: NoRowsOverlay,
+            }}
+            initialState={{ pagination: { paginationModel: { pageSize: pageSizeConfig.pageSize }, } }}
+            pageSizeOptions={pageSizeConfig.pageSizeOptions}
+            density={density}
+            checkboxSelection={checkboxSelection}
+            onRowSelectionModelChange={(model) => {
+              const selectionDataReference =
+                registryIdToDataReference(information.desc.name) +
+                '/Selection';
+              addQueryResult(selectionDataReference, model);
+            }}
+          />
+        )}
+        <BottomActions
+          uiOptions={uiOptions}
+          defaultService={normalizedDefaultService}
+          jexlCtx={jexlCtx}
+          sx={{ marginTop: theme.spacing(2) }}
+        />
+      </Box>
+    );
+  }
+}

--- a/packages/fe/src/app/components/core/views/make-standard-state-view-component.tsx
+++ b/packages/fe/src/app/components/core/views/make-standard-state-view-component.tsx
@@ -1,0 +1,141 @@
+import {ValueObjectRuntimeInfo} from "@event-engine/messaging/value-object";
+import {ViewRuntimeConfig} from "@frontend/app/components/core/views/view-runtime-config";
+import {usePageData} from "@frontend/hooks/use-page-data";
+import {determineQueryPayload} from "@app/shared/utils/determine-query-payload";
+import {useUser} from "@frontend/hooks/use-user";
+import {useGlobalStore} from "@frontend/hooks/use-global-store";
+import {merge} from "lodash/fp";
+import jexl from "@app/shared/jexl/get-configured-jexl";
+import {useEffect} from "react";
+import {getInitialValuesFromUiSchema} from "@frontend/util/command-form/get-initial-values";
+import {JSONSchema7} from "json-schema";
+import {CircularProgress, useTheme} from "@mui/material";
+import FormView from "@frontend/app/components/core/FormView";
+import StateView from "@frontend/app/components/core/StateView";
+import {useApiQuery} from "@frontend/queries/use-api-query";
+import {QueryRuntimeInfo} from "@event-engine/messaging/query";
+import {
+  isQueryableDescription,
+} from "@event-engine/descriptions/descriptions";
+import {get} from "lodash";
+import {normalizeUiSchema} from "@frontend/util/schema/normalize-ui-schema";
+import {useEnv} from "@frontend/hooks/use-env";
+import {registryIdToDataReference} from "@app/shared/utils/registry-id-to-data-reference";
+
+export const makeStandardStateViewComponent = (information: ValueObjectRuntimeInfo, queryInfo: QueryRuntimeInfo) => {
+  return (props: object & {hidden?: boolean}, config: ViewRuntimeConfig) => {
+    const env = useEnv();
+    const [page] = usePageData();
+    const [user] = useUser();
+    const [store] = useGlobalStore();
+    const theme = useTheme();
+
+    if (
+      !isQueryableDescription(information.desc)
+    ) {
+      throw new Error(
+        `Play state view can only be used to show queriable information, but "${information.desc.name}" is not of this information type.`
+      );
+    }
+
+    const uiSchema = merge(
+      information.uiSchema || {},
+      config.uiSchemaOverride || {}
+    );
+
+    const [, addQueryResult] = usePageData();
+
+    // Prepare the main query
+    const queryParams = get(uiSchema, 'ui:query', props);
+
+    const jexlQueryCtx = {
+      theme,
+      routeParams: props,
+      user,
+      page,
+      store,
+      data: {},
+    };
+
+    const query = useApiQuery(
+      queryInfo.desc.name,
+      determineQueryPayload(
+        normalizeUiSchema(queryParams, jexlQueryCtx, env),
+        queryInfo
+      ),
+      {},
+      !config.loadState
+    );
+
+
+    const jexlCtx = {
+      theme,
+      routeParams: props,
+      user,
+      page,
+      store,
+      mode: config.pageMode === 'dialog' ? 'dialogView' : 'pageView',
+    };
+
+    let isHidden = config.isHiddenView;
+
+    if (!isHidden && typeof uiSchema['ui:hidden'] !== 'undefined') {
+      if (typeof uiSchema['ui:hidden'] === 'string') {
+        isHidden = jexl.evalSync(uiSchema['ui:hidden'], jexlCtx);
+        delete uiSchema['ui:hidden'];
+      } else {
+        isHidden = uiSchema['ui:hidden'];
+      }
+    }
+
+    useEffect(() => {
+      addQueryResult(registryIdToDataReference(information.desc.name), query);
+    }, [query.dataUpdatedAt]);
+
+    const initialValues =
+      config.injectedInitialValues ||
+      getInitialValuesFromUiSchema(
+        uiSchema,
+        information.schema as unknown as JSONSchema7,
+        jexlCtx
+      );
+    const state = query.isSuccess
+      ? merge(initialValues, query.data)
+      : initialValues;
+
+    if (isHidden) {
+      return <></>;
+    }
+
+    if (query.isLoading) {
+      return <CircularProgress />;
+    }
+
+    if (config.viewType === 'form') {
+      return (
+        <>
+          {query.isSuccess && (
+            <FormView
+              pageMode={config.pageMode}
+              description={{ ...information, uiSchema }}
+              state={state}
+              onSubmitted={() => (config.loadState ? query.refetch() : undefined)}
+            />
+          )}
+        </>
+      );
+    } else {
+      return (
+        <>
+          {query.isSuccess && (
+            <StateView
+              mode={config.pageMode === 'dialog' ? 'dialogView' : 'pageView'}
+              description={{ ...information, uiSchema }}
+              state={state}
+            />
+          )}
+        </>
+      );
+    }
+  }
+}

--- a/packages/fe/src/app/components/core/views/make-static-state-view-component.tsx
+++ b/packages/fe/src/app/components/core/views/make-static-state-view-component.tsx
@@ -1,0 +1,77 @@
+import {ValueObjectRuntimeInfo} from "@event-engine/messaging/value-object";
+import {ViewRuntimeConfig} from "@frontend/app/components/core/views/view-runtime-config";
+import {usePageData} from "@frontend/hooks/use-page-data";
+import {useUser} from "@frontend/hooks/use-user";
+import {useGlobalStore} from "@frontend/hooks/use-global-store";
+import {merge} from "lodash/fp";
+import jexl from "@app/shared/jexl/get-configured-jexl";
+import {getInitialValuesFromUiSchema} from "@frontend/util/command-form/get-initial-values";
+import {JSONSchema7} from "json-schema";
+import {useTheme} from "@mui/material";
+import FormView from "@frontend/app/components/core/FormView";
+import StateView from "@frontend/app/components/core/StateView";
+
+export const makeStaticStateViewComponent = (information: ValueObjectRuntimeInfo) => {
+  return (props: object & {hidden?: boolean}, config: ViewRuntimeConfig) => {
+    const [page] = usePageData();
+    const [user] = useUser();
+    const [store] = useGlobalStore();
+    const theme = useTheme();
+
+    const uiSchema = merge(
+      information.uiSchema || {},
+      config.uiSchemaOverride || {}
+    );
+
+    const jexlCtx = {
+      theme,
+      routeParams: props,
+      user,
+      page,
+      store,
+      mode: config.pageMode === 'dialog' ? 'dialogView' : 'pageView',
+    };
+
+    let isHidden = config.isHiddenView;
+
+    if (!isHidden && typeof uiSchema['ui:hidden'] !== 'undefined') {
+      if (typeof uiSchema['ui:hidden'] === 'string') {
+        isHidden = jexl.evalSync(uiSchema['ui:hidden'], jexlCtx);
+        delete uiSchema['ui:hidden'];
+      } else {
+        isHidden = uiSchema['ui:hidden'];
+      }
+    }
+
+
+    const initialValues =
+      config.injectedInitialValues ||
+      getInitialValuesFromUiSchema(
+        uiSchema,
+        information.schema as unknown as JSONSchema7,
+        jexlCtx
+      );
+
+    if (isHidden) {
+      return <></>;
+    }
+
+    if (config.viewType === 'form') {
+      return (
+        <FormView
+          pageMode={config.pageMode}
+          description={{ ...information, uiSchema }}
+          state={initialValues}
+        />
+      );
+    } else {
+      return (
+        <StateView
+          mode={config.pageMode === 'dialog' ? 'dialogView' : 'pageView'}
+          description={{ ...information, uiSchema }}
+          state={initialValues}
+        />
+      );
+    }
+  }
+}

--- a/packages/fe/src/app/pages/dialog-page.tsx
+++ b/packages/fe/src/app/pages/dialog-page.tsx
@@ -81,7 +81,6 @@ const DialogPage = (props: DialogPageProps) => {
                      alignItems="center"
                      justifyContent="flex-end">
               <IconButton sx={{
-                marginRight: `-${theme.spacing(2)}`,
                 color: theme.palette.grey[500],
               }} onClick={handleClose}>
                 <Close />

--- a/packages/fe/src/extensions/app/layout/theme.ts.cetmpl
+++ b/packages/fe/src/extensions/app/layout/theme.ts.cetmpl
@@ -1,4 +1,5 @@
 import {Theme, ThemeOptions} from "@mui/material";
+import {playshot} from "@frontend/playconfig/playshot";
 
 /**
  * Theme configuration variables are:
@@ -14,9 +15,10 @@ import {Theme, ThemeOptions} from "@mui/material";
 // @ts-ignore
 const overwriteThemeOptions = (theme: Theme): ThemeOptions => {
   return {
-
+    ...playshot.theme,
   } as ThemeOptions;
 };
 
 
 export default overwriteThemeOptions;
+

--- a/packages/fe/src/main.tsx
+++ b/packages/fe/src/main.tsx
@@ -2,12 +2,16 @@ import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import App from './app/app';
 import {environment} from "@frontend/environments/environment";
+import {bootstrapPlayFrontend} from "@frontend/playconfig/bootstrap-play-frontend";
 
 document.title = environment.appName;
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
+
+bootstrapPlayFrontend();
+
 root.render(
   <StrictMode>
     <App />

--- a/packages/fe/src/playconfig/bootstrap-play-frontend.ts
+++ b/packages/fe/src/playconfig/bootstrap-play-frontend.ts
@@ -1,0 +1,217 @@
+import {playshot} from "@frontend/playconfig/playshot";
+import {commands as commandTypes} from "@app/shared/commands";
+import {makeCommandFactory} from "@cody-play/infrastructure/commands/make-command-factory";
+import definitions from "@app/shared/types/definitions";
+import {
+  PlayPageDefinition,
+  PlaySchemaDefinitions,
+  PlayTopLevelPage,
+  PlayViewComponentConfig
+} from "@cody-play/state/types";
+import {DevLogger} from "@frontend/util/Logger";
+import {commands as commandComponents} from "@frontend/app/components/commands";
+import {makeStandardCommandComponent} from "@frontend/app/components/core/commands/make-standard-command-component";
+import {types} from "@app/shared/types";
+import {makeInformationFactory} from "@cody-play/infrastructure/information/make-information-factory";
+import {playDefinitionIdFromFQCN} from "@cody-play/infrastructure/cody/schema/play-definition-id";
+import {queries} from "@app/shared/queries";
+import {makeQueryFactory} from "@cody-play/queries/make-query-factory";
+import {views} from "@frontend/app/components/views";
+import {
+  isQueryableDescription,
+  isQueryableListDescription,
+  isQueryableNotStoredStateListDescription,
+  isQueryableStateListDescription
+} from "@event-engine/descriptions/descriptions";
+import {makeStandardListViewComponent} from "@frontend/app/components/core/views/make-standard-list-view-component";
+import {makeStandardStateViewComponent} from "@frontend/app/components/core/views/make-standard-state-view-component";
+import {makeStaticStateViewComponent} from "@frontend/app/components/core/views/make-static-state-view-component";
+import {pages} from "@frontend/app/pages";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+import {getBreadcrumbFnFromPlayPage} from "@frontend/playconfig/utils/get-breadcrumb-fn-from-play-page";
+import {isTopLevelPage, PageDefinition, TopLevelPage} from "@frontend/app/pages/page-definitions";
+import {makeMdiIcon} from "@frontend/app/components/core/views/make-mdi-icon";
+import {Personas} from "@app/shared/extensions/personas";
+
+export const bootstrapPlayFrontend = () => {
+  registerTypes();
+  registerCommands();
+  registerQueries();
+  registerViews();
+  registerPages();
+  registerPersonas();
+}
+
+const registerTypes = () => {
+  for (const typeName in playshot.types) {
+    const information = playshot.types[typeName];
+
+    if(types[typeName]) {
+      DevLogger.log(`[CodyPlay] Skipping play type "${typeName}". A custom type is configured.`);
+      continue;
+    }
+
+    types[typeName] = {
+      desc: information.desc,
+      schema: information.schema,
+      uiSchema: information.uiSchema,
+      factory: makeInformationFactory(information.factory)
+    };
+
+    (definitions as any)[playDefinitionIdFromFQCN(typeName)] = information.schema;
+
+    DevLogger.log(`[CodyPlay] Registered play type "${typeName}".`);
+  }
+}
+
+const registerCommands = () => {
+  for (const commandName in playshot.commands) {
+    if(commandTypes[commandName]) {
+      DevLogger.log(`[CodyPlay] Skipping play command "${commandName}". A custom command is configured.`)
+      continue;
+    }
+
+    const command = playshot.commands[commandName];
+
+    commandTypes[commandName] = {
+      desc: command.desc,
+      schema: command.schema,
+      uiSchema: command.uiSchema,
+      factory: makeCommandFactory(command, definitions as unknown as PlaySchemaDefinitions)
+    }
+
+    DevLogger.log(`[CodyPlay] Registered play command "${commandName}".`)
+
+    if(commandComponents[commandName]) {
+      DevLogger.log(`[CodyPlay] Skipping play command component "${commandName}". A custom component is configured.`);
+      continue;
+    }
+
+    commandComponents[commandName] = makeStandardCommandComponent(commandTypes[commandName]);
+
+    DevLogger.log(`[CodyPlay] Registered play command component "${commandName}"`);
+  }
+}
+
+const registerQueries = () => {
+  for (const queryName in playshot.queries) {
+    if(queries[queryName]) {
+      DevLogger.log(`[CodyPlay] Skipping play query "${queryName}". A custom query is configured.`)
+      continue;
+    }
+
+    const query = playshot.queries[queryName];
+
+    queries[queryName] = {
+      desc: query.desc,
+      schema: query.schema,
+      factory: makeQueryFactory(query, definitions as unknown as PlaySchemaDefinitions)
+    }
+
+    DevLogger.log(`[CodyPlay] Registered play query "${queryName}".`)
+  }
+}
+
+const registerViews = () => {
+  for (const viewName in playshot.views) {
+    if(views[viewName]) {
+      DevLogger.log(`[CodyPlay] Skipping play view "${viewName}". A custom view is configured.`);
+      continue;
+    }
+
+    const viewConfig = playshot.views[viewName] as PlayViewComponentConfig;
+
+    const information  = types[viewConfig.information];
+
+    if(!information) {
+      DevLogger.warn(`[CodyPlay] Skipping view registration of view "${viewName}". Connected type "${viewConfig.information}" cannot be found in the types registry.`);
+    }
+
+    if (
+      !isQueryableStateListDescription(information.desc) &&
+      !isQueryableListDescription(information.desc) &&
+      !isQueryableNotStoredStateListDescription(information.desc)
+    ) {
+      if(!isQueryableDescription(information.desc)) {
+        views[viewName] = makeStaticStateViewComponent(information);
+
+        DevLogger.log(`[CodyPlay] Registered play static view component "${viewName}".`);
+      } else {
+        const query = queries[information.desc.query];
+
+        if(!query) {
+          DevLogger.warn(`[CodyPlay] Skipping view registration of view "${viewName}". Query "${information.desc.query}" cannot be found in the query registry.`);
+          continue;
+        }
+
+        views[viewName] = makeStandardStateViewComponent(information, query);
+
+        DevLogger.log(`[CodyPlay] Registered play state view component "${viewName}".`);
+      }
+    } else {
+      views[viewName] = makeStandardListViewComponent(information);
+
+      DevLogger.log(`[CodyPlay] Registered play list view component "${viewName}".`);
+    }
+  }
+}
+
+const registerPages = () => {
+  const pagesCopy = {...pages};
+
+  for(const customPageName in pages) {
+    delete pages[customPageName];
+  }
+
+  for (const pageName in playshot.pages) {
+    if(pageName === "Welcome") {
+      continue;
+    }
+
+    if(pagesCopy[pageName]) {
+      DevLogger.log(`[CodyPlay] Skipping play page "${pageName}". A custom page is configured.`);
+      continue;
+    }
+
+    let page = playshot.pages[pageName];
+
+    if(isTopLevelPage(page as PageDefinition)) {
+      page = normalizeSidebar(page) as PlayPageDefinition;
+    }
+
+    pages[pageName] = {
+      ...page,
+      breadcrumb: getBreadcrumbFnFromPlayPage(playshot.pages[pageName], playshot as CodyPlayConfig)
+    };
+
+    DevLogger.log(`[CodyPlay] Registered play page "${pageName}".`);
+  }
+
+  for(const copyPageName in pagesCopy) {
+    pages[copyPageName] = pagesCopy[copyPageName];
+  }
+}
+
+const normalizeSidebar = (page: any): TopLevelPage => {
+  return {
+    ...page,
+    sidebar: {
+      ...(page as TopLevelPage).sidebar,
+      Icon: makeMdiIcon((page as PlayTopLevelPage).sidebar.icon) as any
+    }
+  }
+}
+
+const registerPersonas = () => {
+  Personas.shift();
+  Personas.reverse();
+
+  playshot.personas.forEach(p => {
+    Personas.unshift(p);
+
+    DevLogger.log(`[CodyPlay] Registered play persona "${p.displayName}".`);
+  });
+
+  Personas.reverse();
+
+}

--- a/packages/fe/src/playconfig/fe-play-config.ts
+++ b/packages/fe/src/playconfig/fe-play-config.ts
@@ -1,0 +1,23 @@
+import {
+  PlayAggregateRegistry,
+  PlayCommandRegistry,
+  PlayEventRegistry,
+  PlayInformationRegistry, PlayPageRegistry,
+  PlayQueryRegistry, PlaySchemaDefinitions, PlayViewRegistry
+} from "@cody-play/state/types";
+import {ThemeOptions} from "@mui/material";
+import {Persona} from "@app/shared/extensions/personas";
+
+export interface FePlayConfig {
+  defaultService: string,
+  commands: PlayCommandRegistry,
+  views: PlayViewRegistry,
+  pages: PlayPageRegistry,
+  aggregates: PlayAggregateRegistry,
+  events: PlayEventRegistry,
+  queries: PlayQueryRegistry,
+  types: PlayInformationRegistry,
+  definitions: PlaySchemaDefinitions,
+  theme: ThemeOptions,
+  personas: Persona[],
+}

--- a/packages/fe/src/playconfig/playshot.ts.cetmpl
+++ b/packages/fe/src/playconfig/playshot.ts.cetmpl
@@ -1,0 +1,12 @@
+import {FePlayConfig} from "@frontend/playconfig/fe-play-config";
+
+export const playshot = {
+  "theme": {},
+  "personas": [],
+  "pages": {},
+  "views": {},
+  "commands": {},
+  "queries": {},
+  "types": {},
+  "definitions": {},
+} as unknown as FePlayConfig;

--- a/packages/fe/src/playconfig/utils/get-breadcrumb-fn-from-play-page.ts
+++ b/packages/fe/src/playconfig/utils/get-breadcrumb-fn-from-play-page.ts
@@ -1,0 +1,52 @@
+import {PlayPageDefinition} from "@cody-play/state/types";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+import {BreadcrumbFn} from "@frontend/app/pages/page-definitions";
+import {staticLabel} from "@frontend/util/breadcrumb/static-label";
+import {isDynamicBreadcrumb} from "@cody-engine/cody/hooks/utils/ui/types";
+import {playGetVoRuntimeInfoFromDataReference} from "@cody-play/state/play-get-vo-runtime-info-from-data-reference";
+import {
+  isQueryableNotStoredValueObjectDescription,
+  isQueryableStateDescription, isQueryableStateListDescription,
+  isQueryableValueObjectDescription
+} from "@event-engine/descriptions/descriptions";
+import {dynamicLabel} from "@frontend/util/breadcrumb/dynamic-label";
+import jexl from "@app/shared/jexl/get-configured-jexl";
+import {makeSyncExecutable} from "@cody-play/infrastructure/rule-engine/make-executable";
+import {getApiQuery} from "@frontend/queries/use-api-query";
+
+export const getBreadcrumbFnFromPlayPage = (page: PlayPageDefinition, config: CodyPlayConfig): BreadcrumbFn => {
+  if(typeof page.breadcrumb === "string") {
+    return staticLabel(page.breadcrumb);
+  } else if (isDynamicBreadcrumb(page.breadcrumb)){
+    const vo = playGetVoRuntimeInfoFromDataReference(page.breadcrumb.data, page.service, config.types);
+    const voDesc = vo.desc;
+
+    if(!isQueryableStateDescription(voDesc) && !isQueryableValueObjectDescription(voDesc) && !isQueryableNotStoredValueObjectDescription(voDesc) && isQueryableStateListDescription(voDesc)) {
+      return staticLabel(`Error! "${voDesc.name}" is not queryable`);
+    }
+
+    const {label} = page.breadcrumb;
+    const query = (voDesc as unknown as {query: string}).query;
+
+    return dynamicLabel(
+      query,
+      params => {
+        return (getApiQuery())(query, params);
+      },
+      data => {
+        let ctx = {data, value: ''};
+
+        if(typeof label === "string") {
+          ctx.value = jexl.evalSync(label, ctx);
+        } else {
+          const exe = makeSyncExecutable(label);
+          ctx = exe(ctx);
+        }
+
+        return ctx.value;
+      }
+    )
+  }
+
+  return staticLabel('Breadcrumb Config Error!');
+}

--- a/packages/fe/src/queries/use-api-query.ts
+++ b/packages/fe/src/queries/use-api-query.ts
@@ -25,10 +25,14 @@ export const getApiQuery = (): ApiQuery => {
   return internalApiQuery;
 }
 
-export const useApiQuery = (queryName: string, params: any, options?: {staleTime?: number}) => {
+export const useApiQuery = (queryName: string, params: any, options?: {staleTime?: number}, disabled?: boolean) => {
   return useQuery({
     queryKey: [queryName, params],
     queryFn: () => {
+      if(disabled) {
+        return {};
+      }
+
       return internalApiQuery(queryName, params);
     },
     ...options

--- a/packages/fe/src/util/Logger.ts
+++ b/packages/fe/src/util/Logger.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-console */
 
 import {enqueueSnackbar} from "notistack";
+import {environment} from "@frontend/environments/environment";
 
 export const Logger = {
     log: (...message: any[]) => console.log(...message),
@@ -16,3 +17,17 @@ export const Logger = {
         console.error(...message)
     },
 };
+
+export const DevLogger = {
+    log: (...message: any[]) => !environment.production && console.log(...message),
+    warn: (...message: any[]) => console.warn(...message),
+    error: (...message: any[]) => {
+        const firstMsg = message[0];
+
+        if(firstMsg && firstMsg instanceof Error) {
+            enqueueSnackbar(firstMsg.message, {variant: "error"});
+        }
+
+        console.error(...message)
+    },
+}

--- a/packages/play/package.json
+++ b/packages/play/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@cody-play/package",
+  "version": "0.0.1"
+}

--- a/packages/play/src/app/components/core/PlayListView.tsx
+++ b/packages/play/src/app/components/core/PlayListView.tsx
@@ -199,7 +199,7 @@ const PlayListView = (
       {query.isLoading && <CircularProgress />}
       {query.isSuccess && (
         <Grid2 container={true} className="CodyListView-grid" {...listGridProps}>
-          {query.data.map((item: any) => <Grid2 key={item[itemIdentifier]} {...itemGridProps}>{PlayStaticView(params, itemInfo, itemPageMode, false, itemsUiSchema, item)}</Grid2>)}
+          {Array.isArray(query.data) && query.data.map((item: any) => <Grid2 key={item[itemIdentifier]} {...itemGridProps}>{PlayStaticView(params, itemInfo, itemPageMode, false, itemsUiSchema, item)}</Grid2>)}
         </Grid2>
       )}
       <BottomActions

--- a/packages/play/src/app/components/core/PlayTableView.tsx
+++ b/packages/play/src/app/components/core/PlayTableView.tsx
@@ -184,7 +184,8 @@ const PlayTableView = (
     pages,
     user,
     types,
-    definitions
+    definitions,
+    names(defaultService).className
   );
 
   if(liveEditMode) {
@@ -261,7 +262,7 @@ const PlayTableView = (
       {query.isSuccess && (
         <DataGrid
           columns={columns}
-          rows={query.data}
+          rows={Array.isArray(query.data) ? query.data : [] }
           getRowId={(row) =>
             itemIdentifier ? row[itemIdentifier] : JSON.stringify(row)
           }
@@ -308,7 +309,7 @@ export default PlayTableView;
 
 type RefQueryMap = { [column: string]: UseQueryResult };
 
-const compileTableColumns = (
+export const compileTableColumns = (
   params: any,
   information: PlayInformationRuntimeInfo,
   uiSchema: TableUiSchema,
@@ -316,11 +317,10 @@ const compileTableColumns = (
   pages: PlayPageRegistry,
   user: User,
   types: PlayInformationRegistry,
-  schemaDefinitions: PlaySchemaDefinitions
+  schemaDefinitions: PlaySchemaDefinitions,
+  defaultService: string
 ): GridColDef[] => {
-  const { config } = useContext(configStore);
   const schema = information.schema;
-  const defaultService = names(config.defaultService).className;
 
   if (!isListSchema(schema) && !isInlineItemsArraySchema(schema)) {
     throw new Error(

--- a/packages/play/src/infrastructure/commands/make-aggregate-command-handler.ts
+++ b/packages/play/src/infrastructure/commands/make-aggregate-command-handler.ts
@@ -11,19 +11,28 @@ export const makeAggregateCommandHandler = (
   commandHandlerRules: AnyRule[],
   eventRegistry: PlayEventRegistry,
   schemaDefinitions: PlaySchemaDefinitions,
-  aggregateDescription: AggregateDescription
+  aggregateDescription: AggregateDescription,
+  verbose = true
 ): AggregateProcessingFunctionWithDeps => {
   return async function* (state: any, command: Command, dependencies: Record<string, any>): AsyncGenerator<Event> {
     let ctx = {information: state, command: command.payload, meta: command.meta, ...dependencies, eventRegistry, schemaDefinitions};
 
-    console.log(
-      `%c[CommandBus] Executing business rules of aggregate command %c${command.name}`, Palette.cColor(Palette.stickyColors.command), Palette.cColorBold(Palette.stickyColors.command),
-      aggregateDescription._pbLink,
-      {
-        ctx,
-        rules: commandHandlerRules
-      }
-    )
+    if(verbose) {
+      console.log(
+        `%c[CommandBus] Executing business rules of aggregate command %c${command.name}`, Palette.cColor(Palette.stickyColors.command), Palette.cColorBold(Palette.stickyColors.command),
+        aggregateDescription._pbLink,
+        {
+          ctx,
+          rules: commandHandlerRules
+        }
+      )
+    } else {
+      console.log(
+        `%c[CommandBus] Executing business rules of aggregate command %c${command.name}`, Palette.cColor(Palette.stickyColors.command), Palette.cColorBold(Palette.stickyColors.command),
+        aggregateDescription._pbLink,
+      )
+    }
+
 
     for (const rule of commandHandlerRules) {
       const [result, nextRule] = await execRuleAsync(rule, ctx);

--- a/packages/play/src/infrastructure/commands/make-pure-command-handler.ts
+++ b/packages/play/src/infrastructure/commands/make-pure-command-handler.ts
@@ -12,18 +12,26 @@ export const makePureCommandHandler = (
   eventRegistry: PlayEventRegistry,
   schemaDefinitions: PlaySchemaDefinitions,
   commandDescription: CommandDescription,
+  verbose = true
 ): ProcessingFunctionWithDeps => {
   return async function* (command: Command, dependencies: Record<string, any>): AsyncGenerator<Event> {
     let ctx = {command: command.payload, meta: command.meta, ...dependencies, eventRegistry, schemaDefinitions};
 
-    console.log(
-      `%c[CommandBus] Executing business rules of %c${command.name}`, Palette.cColor(Palette.stickyColors.command), Palette.cColorBold(Palette.stickyColors.command),
-      commandDescription._pbLink,
-      {
-        ctx,
-        rules: commandHandlerRules
-      }
-    )
+    if(verbose) {
+      console.log(
+        `%c[CommandBus] Executing business rules of %c${command.name}`, Palette.cColor(Palette.stickyColors.command), Palette.cColorBold(Palette.stickyColors.command),
+        commandDescription._pbLink,
+        {
+          ctx,
+          rules: commandHandlerRules
+        }
+      )
+    } else {
+      console.log(
+        `%c[CommandBus] Executing business rules of %c${command.name}`, Palette.cColor(Palette.stickyColors.command), Palette.cColorBold(Palette.stickyColors.command),
+        commandDescription._pbLink,
+      )
+    }
 
     for (const rule of commandHandlerRules) {
       const [result, nextRule] = await execRuleAsync(rule, ctx);

--- a/packages/play/src/queries/local-api-query.ts
+++ b/packages/play/src/queries/local-api-query.ts
@@ -1,49 +1,19 @@
 import {ApiQuery} from "@frontend/queries/use-api-query";
 import {getConfiguredPlayDocumentStore} from "@cody-play/infrastructure/multi-model-store/configured-document-store";
-import {asyncIteratorToArray} from "@event-engine/infrastructure/helpers/async-iterator-to-array";
-import {asyncMap} from "@event-engine/infrastructure/helpers/async-map";
 import {CodyPlayConfig} from "@cody-play/state/config-store";
 import {CONTACT_PB_TEAM} from "@cody-play/infrastructure/error/message";
-import {
-  isQueryableListDescription,
-  isQueryableNotStoredStateDescription,
-  isQueryableNotStoredStateListDescription,
-  isQueryableNotStoredValueObjectDescription,
-  isQueryableStateDescription,
-  isQueryableStateListDescription,
-  isQueryableValueObjectDescription, isStoredQueryableListDescription,
-  QueryableListDescription,
-  QueryableNotStoredStateDescription, QueryableNotStoredValueObjectDescription,
-  QueryableStateDescription,
-  QueryableStateListDescription,
-  QueryableValueObjectDescription, StoredQueryableListDescription
-} from "@event-engine/descriptions/descriptions";
-import {PlayQueryRuntimeInfo} from "@cody-play/state/types";
-import {NotFoundError} from "@event-engine/messaging/error/not-found-error";
 import {determineQueryPayload} from "@app/shared/utils/determine-query-payload";
 import {QueryRuntimeInfo} from "@event-engine/messaging/query";
 import {User} from "@app/shared/types/core/user/user";
-import {JSONSchema7} from "json-schema-to-ts";
-import {SortOrder, SortOrderItem} from "@event-engine/infrastructure/DocumentStore";
-import {AnyRule} from "@app/shared/rule-engine/configuration";
-import {makeInformationFactory} from "@cody-play/infrastructure/information/make-information-factory";
-import {ResolveConfig} from "@cody-engine/cody/hooks/utils/value-object/types";
-import {
-  makeFiltersFromQuerySchema,
-  makeFiltersFromResolveConfig,
-} from "@cody-play/queries/make-filters";
-import {mapOrderBy} from "@cody-engine/cody/hooks/utils/query/map-order-by";
 import {
   playInformationServiceFactory
 } from "@cody-play/infrastructure/infromation-service/play-information-service-factory";
-import {INFORMATION_SERVICE_NAME} from "@event-engine/infrastructure/information-service/information-service";
-import {validateResolverRules} from "@cody-engine/cody/hooks/rule-engine/validate-resolver-rules";
-import {makeAsyncExecutable} from "@cody-play/infrastructure/rule-engine/make-executable";
 import {playLoadDependencies} from "@cody-play/infrastructure/cody/dependencies/play-load-dependencies";
 import {makeQueryFactory} from "@cody-play/queries/make-query-factory";
-import {Palette} from "@cody-play/infrastructure/utils/styles";
-
-type ResolvedCtx = {query: Record<string, unknown>, meta: {user: User}, information?: unknown} & Record<string, unknown>;
+import {
+  resolve,
+  ResolvedCtx,
+} from "@cody-play/queries/resolve";
 
 const ds = getConfiguredPlayDocumentStore();
 const infoService = playInformationServiceFactory();
@@ -65,243 +35,13 @@ export const makeLocalApiQuery = (store: CodyPlayConfig, user: User): ApiQuery =
       throw new Error(`Cannot find Information about query return type: "${informationName}" of query: "${queryName}". ${CONTACT_PB_TEAM}`);
     }
 
-    const informationDesc = informationInfo.desc;
-    const resolve = store.resolvers[queryName] || {};
+    const resolveConfig = store.resolvers[queryName] || {};
     const queryFactory = makeQueryFactory(queryInfo, store.definitions);
     const payload = determineQueryPayload(params, queryInfo as unknown as QueryRuntimeInfo)
     const dependencies = await playLoadDependencies(queryFactory(payload, {user}), 'query', queryInfo.desc.dependencies || {}, store);
 
-    let resolvedCtx: ResolvedCtx = {...dependencies, query: params, meta: {user}};
+    const resolvedCtx: ResolvedCtx = {...dependencies, query: params, meta: {user}};
 
-    if(resolve.rules) {
-      const rulesCtx: Record<string, unknown> = {...dependencies, query: params, meta: {user}};
-      rulesCtx[INFORMATION_SERVICE_NAME] = infoService;
-
-      validateResolverRules(resolve.rules);
-
-      resolvedCtx = await (makeAsyncExecutable(resolve.rules))(rulesCtx);
-
-      console.log(
-        `%c[QueryBus] Executed resolve rules of query %c${queryName}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
-        informationDesc._pbLink,
-        {
-          resolvedCtx,
-          rules: resolve.rules
-        }
-      )
-    }
-
-    if(isQueryableNotStoredStateDescription(informationDesc)) {
-      return await resolveNotStoredStateQuery(informationDesc, informationInfo.factory, queryInfo, resolvedCtx);
-    }
-
-    if(isQueryableStateDescription(informationDesc)) {
-      return await resolveStateQuery(informationDesc, informationInfo.factory, queryInfo, resolvedCtx.query);
-    }
-
-    if(isQueryableNotStoredStateListDescription(informationDesc)) {
-      const itemInfo = store.types[informationDesc.itemType];
-
-      if(!itemInfo) {
-        throw new Error(`[CodyPlay] List item type "${informationDesc.itemType}" is unknown. Did you forget to pass it from prooph board to Cody Play?`)
-      }
-
-      return await resolveNotStoredListQuery(informationDesc, itemInfo.factory, queryInfo, resolve, resolvedCtx);
-    }
-
-    if(isQueryableStateListDescription(informationDesc)) {
-      let itemInfo = store.types[informationDesc.itemType];
-
-      if(!itemInfo) {
-        // @TODO: throw exception, but ensure BC first
-        // throw new Error(`[CodyPlay] List item type "${informationDesc.itemType}" is unknown. Did you forget to pass it from prooph board to Cody Play?`)
-        itemInfo = informationInfo;
-      }
-
-      return await resolveStateListQuery(informationDesc, itemInfo.factory, queryInfo, resolve, resolvedCtx.query, user)
-    }
-
-    if(isQueryableValueObjectDescription(informationDesc)) {
-      return await resolveSingleValueObjectQuery(informationDesc, informationInfo.factory, queryInfo, resolve, resolvedCtx.query, user);
-    }
-
-    if(isQueryableNotStoredValueObjectDescription(informationDesc)) {
-      return await resolveNotStoredValueObjectQuery(informationDesc, informationInfo.factory, queryInfo, resolvedCtx);
-    }
-
-    if(isQueryableListDescription(informationDesc)) {
-      let itemInfo = store.types[informationDesc.itemType];
-
-      if(!itemInfo) {
-        // @TODO: throw exception, but ensure BC first
-        // throw new Error(`[CodyPlay] List item type "${informationDesc.itemType}" is unknown. Did you forget to pass it from prooph board to Cody Play?`)
-        itemInfo = informationInfo;
-      }
-
-      if(isStoredQueryableListDescription(informationDesc)) {
-        return await resolveStateListQuery(informationDesc, itemInfo.factory, queryInfo, resolve, resolvedCtx.query, user);
-      }
-
-      return await resolveNotStoredListQuery(informationDesc, itemInfo.factory, queryInfo, resolve, resolvedCtx);
-    }
-
-    throw new Error(`Cannot resolve query "${queryName}", because the query return type is not supported. ${CONTACT_PB_TEAM}`);
+    return resolve(ds, infoService, resolveConfig, informationInfo, queryInfo, resolvedCtx, store, user, true);
   }
 }
-
-const resolveNotStoredStateQuery = async (desc: QueryableNotStoredStateDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, ctx: ResolvedCtx): Promise<any> => {
-  const doc = ctx.information;
-
-  if(!doc) {
-    throw new NotFoundError(`"${desc.name}" with "${desc.identifier}": "${ctx.query[desc.identifier]}" not found!`);
-  }
-
-  console.log(
-    `%c[QueryBus] Performed not stored state query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
-    desc._pbLink,
-    {
-      ctx,
-      result: doc
-    }
-  )
-
-  const exe = makeInformationFactory(factory);
-
-  return exe(doc);
-}
-
-const resolveNotStoredValueObjectQuery = async (desc: QueryableNotStoredValueObjectDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, ctx: ResolvedCtx): Promise<any> => {
-  const doc = ctx.information;
-
-  if(!doc) {
-    throw new NotFoundError(`"${desc.name}" with "${ctx.query}" not found!`);
-  }
-
-  console.log(
-    `%c[QueryBus] Performed not stored ValueObject query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
-    desc._pbLink,
-    {
-      ctx,
-      result: doc
-    }
-  )
-
-  const exe = makeInformationFactory(factory);
-
-  return exe(doc);
-}
-
-const resolveStateQuery = async (desc: QueryableStateDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, params: any): Promise<any> => {
-  if(typeof params !== "object" || !params[desc.identifier]) {
-    throw new Error(`Cannot resolve query: "${queryInfo.desc.name}". Query property "${desc.identifier}" is missing in query payload. This error can be caused by a wrong mapping. Please check potential metadata configuration.`);
-  }
-
-  const doc = await ds.getDoc<any>(desc.collection, params[desc.identifier]);
-
-  if(!doc) {
-    throw new NotFoundError(`"${desc.name}" with "${desc.identifier}": "${params[desc.identifier]}" not found!`);
-  }
-
-  console.log(
-    `%c[QueryBus] Performed State query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
-    desc._pbLink,
-    {
-      params,
-      result: doc
-    }
-  )
-
-  const exe = makeInformationFactory(factory);
-
-  return exe(doc);
-}
-
-const resolveStateListQuery = async (desc: QueryableStateListDescription | StoredQueryableListDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, params: any, user: User): Promise<Array<any>> => {
-  const queryPayload = determineQueryPayload(params, queryInfo as unknown as QueryRuntimeInfo);
-
-  const filters = resolve.where ? makeFiltersFromResolveConfig(desc, resolve, queryPayload, user) : makeFiltersFromQuerySchema(queryInfo.schema as JSONSchema7, queryPayload, user);
-
-  let orderBy: SortOrder | undefined = undefined;
-
-  if(resolve.orderBy) {
-    orderBy = mapOrderBy(resolve.orderBy);
-  }
-
-  const exe = makeInformationFactory(factory);
-
-  const cursor = await ds.findDocs<any>(desc.collection, filters, undefined, undefined, orderBy);
-
-  const result = asyncIteratorToArray(asyncMap(cursor, ([, d]) => exe(d)));
-
-  console.log(
-    `%c[QueryBus] Performed StateList query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
-    desc._pbLink,
-    {
-      queryPayload,
-      result
-    }
-  )
-
-  return result;
-}
-
-const resolveSingleValueObjectQuery = async (desc: QueryableValueObjectDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, params: any, user: User): Promise<any> => {
-  const queryPayload = determineQueryPayload(params, queryInfo as unknown as QueryRuntimeInfo);
-
-  const filters = resolve.where
-    ? makeFiltersFromResolveConfig(desc, resolve, params, user) :
-      makeFiltersFromQuerySchema(queryInfo.schema as JSONSchema7, params, user);
-
-  let orderBy: SortOrder | undefined = undefined;
-
-  if(resolve.orderBy) {
-    orderBy = mapOrderBy(resolve.orderBy);
-  }
-
-  const exe = makeInformationFactory(factory);
-
-  const cursor = await ds.findDocs<any>(desc.collection, filters, undefined, 1, orderBy);
-
-  const result = await asyncIteratorToArray(asyncMap(cursor, ([, d]) => exe(d)));
-
-  if(result.length !== 1) {
-    throw new NotFoundError(`"${desc.name}" with "${JSON.stringify(params)}" not found!`);
-  }
-
-  console.log(
-    `%c[QueryBus] Performed SingleValueObject query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
-    desc._pbLink,
-    {
-      filters,
-      result: result[0]
-    }
-  )
-
-  return result[0];
-}
-
-const resolveNotStoredListQuery = async (desc: QueryableListDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, ctx: ResolvedCtx): Promise<any> => {
-  const exe = makeInformationFactory(factory);
-
-  if(!ctx.information) {
-    throw new Error(`[CodyPlay] Query resolver rules for ${desc.name} do not assign an "information" variable. The variable should contain the query result. Please check your prooph board query resolver rules.`)
-  }
-
-  const result = ctx.information;
-
-  if(!Array.isArray(result)) {
-    throw new Error(`[CodyPlay] Query resolver "information" result for ${desc.name} is not a list, but the data schema is defined as a list. Please check your prooph board query resolver rules.`)
-  }
-
-  console.log(
-    `%c[QueryBus] Performed not stored List query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
-    desc._pbLink,
-    {
-      ctx,
-      result
-    }
-  )
-
-  return result.map(item => exe(item));
-}
-

--- a/packages/play/src/queries/resolve.ts
+++ b/packages/play/src/queries/resolve.ts
@@ -1,0 +1,326 @@
+import {
+  isQueryableListDescription,
+  isQueryableNotStoredStateDescription,
+  isQueryableNotStoredStateListDescription, isQueryableNotStoredValueObjectDescription,
+  isQueryableStateDescription,
+  isQueryableStateListDescription, isQueryableValueObjectDescription, isStoredQueryableListDescription,
+  QueryableListDescription,
+  QueryableNotStoredStateDescription,
+  QueryableNotStoredValueObjectDescription,
+  QueryableStateDescription,
+  QueryableStateListDescription,
+  QueryableValueObjectDescription,
+  StoredQueryableListDescription
+} from "@event-engine/descriptions/descriptions";
+import {AnyRule} from "@app/shared/rule-engine/configuration";
+import {PlayInformationRuntimeInfo, PlayQueryRuntimeInfo} from "@cody-play/state/types";
+import {ResolveConfig} from "@cody-engine/cody/hooks/utils/value-object/types";
+import {makeInformationFactory} from "@cody-play/infrastructure/information/make-information-factory";
+import {Palette} from "@cody-play/infrastructure/utils/styles";
+import {User} from "@app/shared/types/core/user/user";
+import {determineQueryPayload} from "@app/shared/utils/determine-query-payload";
+import {QueryRuntimeInfo} from "@event-engine/messaging/query";
+import {makeFiltersFromQuerySchema, makeFiltersFromResolveConfig} from "@cody-play/queries/make-filters";
+import {JSONSchema7} from "json-schema-to-ts";
+import {DocumentStore, SortOrder} from "@event-engine/infrastructure/DocumentStore";
+import {mapOrderBy} from "@cody-engine/cody/hooks/utils/query/map-order-by";
+import {asyncIteratorToArray} from "@event-engine/infrastructure/helpers/async-iterator-to-array";
+import {asyncMap} from "@event-engine/infrastructure/helpers/async-map";
+import {NotFoundError} from "@event-engine/messaging/error/not-found-error";
+import {
+  INFORMATION_SERVICE_NAME,
+  InformationService
+} from "@event-engine/infrastructure/information-service/information-service";
+import {validateResolverRules} from "@cody-engine/cody/hooks/rule-engine/validate-resolver-rules";
+import {makeAsyncExecutable} from "@cody-play/infrastructure/rule-engine/make-executable";
+import {CONTACT_PB_TEAM} from "@cody-play/infrastructure/error/message";
+import {CodyPlayConfig} from "@cody-play/state/config-store";
+
+export type ResolvedCtx = {query: Record<string, unknown>, meta: {user: User}, information?: unknown} & Record<string, unknown>;
+
+export const resolve = async (ds: DocumentStore, infoService: InformationService, resolveConfig: ResolveConfig, information: PlayInformationRuntimeInfo, queryInfo: PlayQueryRuntimeInfo, ctx: ResolvedCtx, playConfig: CodyPlayConfig, user: User, verbose = true) => {
+  if(resolveConfig.rules) {
+    ctx[INFORMATION_SERVICE_NAME] = infoService;
+
+    validateResolverRules(resolveConfig.rules);
+
+    ctx = await (makeAsyncExecutable(resolveConfig.rules))(ctx);
+
+    if(verbose) {
+      console.log(
+        `%c[QueryBus] Executed resolve rules of query %c${queryInfo.desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+        information.desc._pbLink,
+        {
+          ctx,
+          rules: resolveConfig.rules
+        }
+      )
+    } else {
+      console.log(
+        `%c[QueryBus] Executed resolve rules of query %c${queryInfo.desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+        information.desc._pbLink,
+      )
+    }
+  }
+
+  const informationDesc = information.desc;
+
+  if(isQueryableNotStoredStateDescription(informationDesc)) {
+    return await resolveNotStoredStateQuery(informationDesc, information.factory, queryInfo, ctx, verbose);
+  }
+
+  if(isQueryableStateDescription(informationDesc)) {
+    return await resolveStateQuery(ds, informationDesc, information.factory, queryInfo, ctx.query, verbose);
+  }
+
+  if(isQueryableNotStoredStateListDescription(informationDesc)) {
+    const itemInfo = playConfig.types[informationDesc.itemType];
+
+    if(!itemInfo) {
+      throw new Error(`[CodyPlay] List item type "${informationDesc.itemType}" is unknown. Did you forget to pass it from prooph board to Cody Play?`)
+    }
+
+    return await resolveNotStoredListQuery(informationDesc, itemInfo.factory, queryInfo, resolveConfig, ctx, verbose);
+  }
+
+  if(isQueryableStateListDescription(informationDesc)) {
+    let itemInfo = playConfig.types[informationDesc.itemType];
+
+    if(!itemInfo) {
+      // @TODO: throw exception, but ensure BC first
+      // throw new Error(`[CodyPlay] List item type "${informationDesc.itemType}" is unknown. Did you forget to pass it from prooph board to Cody Play?`)
+      itemInfo = information;
+    }
+
+    return await resolveStateListQuery(ds, informationDesc, itemInfo.factory, queryInfo, resolveConfig, ctx.query, user, verbose)
+  }
+
+  if(isQueryableValueObjectDescription(informationDesc)) {
+    return await resolveSingleValueObjectQuery(ds, informationDesc, information.factory, queryInfo, resolveConfig, ctx.query, user, verbose);
+  }
+
+  if(isQueryableNotStoredValueObjectDescription(informationDesc)) {
+    return await resolveNotStoredValueObjectQuery(informationDesc, information.factory, queryInfo, ctx, verbose);
+  }
+
+  if(isQueryableListDescription(informationDesc)) {
+    let itemInfo = playConfig.types[informationDesc.itemType];
+
+    if(!itemInfo) {
+      // @TODO: throw exception, but ensure BC first
+      // throw new Error(`[CodyPlay] List item type "${informationDesc.itemType}" is unknown. Did you forget to pass it from prooph board to Cody Play?`)
+      itemInfo = information;
+    }
+
+    if(isStoredQueryableListDescription(informationDesc)) {
+      return await resolveStateListQuery(ds, informationDesc, itemInfo.factory, queryInfo, resolveConfig, ctx.query, user, verbose);
+    }
+
+    return await resolveNotStoredListQuery(informationDesc, itemInfo.factory, queryInfo, resolveConfig, ctx, verbose);
+  }
+
+  throw new Error(`Cannot resolve query "${queryInfo.desc.name}", because the query return type is not supported. ${CONTACT_PB_TEAM}`);
+}
+
+const resolveNotStoredStateQuery = async (desc: QueryableNotStoredStateDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, ctx: ResolvedCtx, verbose: boolean): Promise<any> => {
+  const doc = ctx.information;
+
+  if(!doc) {
+    throw new NotFoundError(`"${desc.name}" with "${desc.identifier}": "${ctx.query[desc.identifier]}" not found!`);
+  }
+
+  if(verbose) {
+    console.log(
+      `%c[QueryBus] Performed not stored state query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+      {
+        ctx,
+        result: doc
+      }
+    )
+  } else {
+    console.log(
+      `%c[QueryBus] Performed not stored state query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+    )
+  }
+
+
+  const exe = makeInformationFactory(factory);
+
+  return exe(doc);
+}
+
+const resolveNotStoredValueObjectQuery = async (desc: QueryableNotStoredValueObjectDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, ctx: ResolvedCtx, verbose: boolean): Promise<any> => {
+  const doc = ctx.information;
+
+  if(!doc) {
+    throw new NotFoundError(`"${desc.name}" with "${ctx.query}" not found!`);
+  }
+
+  if(verbose) {
+    console.log(
+      `%c[QueryBus] Performed not stored ValueObject query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+      {
+        ctx,
+        result: doc
+      }
+    )
+  } else {
+    console.log(
+      `%c[QueryBus] Performed not stored ValueObject query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+    )
+  }
+
+
+  const exe = makeInformationFactory(factory);
+
+  return exe(doc);
+}
+
+const resolveStateQuery = async (ds: DocumentStore, desc: QueryableStateDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, params: any, verbose: boolean): Promise<any> => {
+  if(typeof params !== "object" || !params[desc.identifier]) {
+    throw new Error(`Cannot resolve query: "${queryInfo.desc.name}". Query property "${desc.identifier}" is missing in query payload. This error can be caused by a wrong mapping. Please check potential metadata configuration.`);
+  }
+
+  const doc = await ds.getDoc<any>(desc.collection, params[desc.identifier]);
+
+  if(!doc) {
+    throw new NotFoundError(`"${desc.name}" with "${desc.identifier}": "${params[desc.identifier]}" not found!`);
+  }
+
+  if(verbose) {
+    console.log(
+      `%c[QueryBus] Performed State query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+      {
+        params,
+        result: doc
+      }
+    )
+  } else {
+    console.log(
+      `%c[QueryBus] Performed State query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+    )
+  }
+
+
+  const exe = makeInformationFactory(factory);
+
+  return exe(doc);
+}
+
+const resolveStateListQuery = async (ds: DocumentStore, desc: QueryableStateListDescription | StoredQueryableListDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, params: any, user: User, verbose: boolean): Promise<Array<any>> => {
+  const queryPayload = determineQueryPayload(params, queryInfo as unknown as QueryRuntimeInfo);
+
+  const filters = resolve.where ? makeFiltersFromResolveConfig(desc, resolve, queryPayload, user) : makeFiltersFromQuerySchema(queryInfo.schema as JSONSchema7, queryPayload, user);
+
+  let orderBy: SortOrder | undefined = undefined;
+
+  if(resolve.orderBy) {
+    orderBy = mapOrderBy(resolve.orderBy);
+  }
+
+  const exe = makeInformationFactory(factory);
+
+  const cursor = await ds.findDocs<any>(desc.collection, filters, undefined, undefined, orderBy);
+
+  const result = asyncIteratorToArray(asyncMap(cursor, ([, d]) => exe(d)));
+
+  if(verbose) {
+    console.log(
+      `%c[QueryBus] Performed StateList query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+      {
+        queryPayload,
+        result
+      }
+    )
+  } else {
+    console.log(
+      `%c[QueryBus] Performed StateList query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+    )
+  }
+
+
+  return result;
+}
+
+const resolveSingleValueObjectQuery = async (ds: DocumentStore, desc: QueryableValueObjectDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, params: any, user: User, verbose: boolean): Promise<any> => {
+  const queryPayload = determineQueryPayload(params, queryInfo as unknown as QueryRuntimeInfo);
+
+  const filters = resolve.where
+    ? makeFiltersFromResolveConfig(desc, resolve, params, user) :
+    makeFiltersFromQuerySchema(queryInfo.schema as JSONSchema7, params, user);
+
+  let orderBy: SortOrder | undefined = undefined;
+
+  if(resolve.orderBy) {
+    orderBy = mapOrderBy(resolve.orderBy);
+  }
+
+  const exe = makeInformationFactory(factory);
+
+  const cursor = await ds.findDocs<any>(desc.collection, filters, undefined, 1, orderBy);
+
+  const result = await asyncIteratorToArray(asyncMap(cursor, ([, d]) => exe(d)));
+
+  if(result.length !== 1) {
+    throw new NotFoundError(`"${desc.name}" with "${JSON.stringify(params)}" not found!`);
+  }
+
+  if(verbose) {
+    console.log(
+      `%c[QueryBus] Performed SingleValueObject query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+      {
+        filters,
+        result: result[0]
+      }
+    )
+  } else {
+    console.log(
+      `%c[QueryBus] Performed SingleValueObject query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+    )
+  }
+
+
+  return result[0];
+}
+
+const resolveNotStoredListQuery = async (desc: QueryableListDescription, factory: AnyRule[], queryInfo: PlayQueryRuntimeInfo, resolve: ResolveConfig, ctx: ResolvedCtx, verbose: boolean): Promise<any> => {
+  const exe = makeInformationFactory(factory);
+
+  if(!ctx.information) {
+    throw new Error(`[CodyPlay] Query resolver rules for ${desc.name} do not assign an "information" variable. The variable should contain the query result. Please check your prooph board query resolver rules.`)
+  }
+
+  const result = ctx.information;
+
+  if(!Array.isArray(result)) {
+    throw new Error(`[CodyPlay] Query resolver "information" result for ${desc.name} is not a list, but the data schema is defined as a list. Please check your prooph board query resolver rules.`)
+  }
+
+  if(verbose) {
+    console.log(
+      `%c[QueryBus] Performed not stored List query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+      {
+        ctx,
+        result
+      }
+    )
+  } else {
+    console.log(
+      `%c[QueryBus] Performed not stored List query %c${desc.name}`, Palette.cColor(Palette.stickyColors.document), Palette.cColorBold(Palette.stickyColors.document),
+      desc._pbLink,
+    )
+  }
+
+  return result.map(item => exe(item));
+}

--- a/packages/play/src/state/config-store.tsx
+++ b/packages/play/src/state/config-store.tsx
@@ -68,6 +68,9 @@ import {getConfiguredPlayEventStore} from "@cody-play/infrastructure/multi-model
 import {getConfiguredPlayDocumentStore} from "@cody-play/infrastructure/multi-model-store/configured-document-store";
 import {services} from "@cody-play/infrastructure/cody/dependencies/play-load-dependencies";
 import {makePlayRulesServiceFactory} from "@cody-play/infrastructure/services/make-play-rules-service-factory";
+import {
+  playInformationServiceFactory
+} from "@cody-play/infrastructure/infromation-service/play-information-service-factory";
 
 export interface CodyPlayConfig {
   appName: string,
@@ -186,7 +189,7 @@ const syncTypesWithSharedRegistry = (config: CodyPlayConfig): void => {
 
 const syncServices = (config: CodyPlayConfig): void => {
   for (const service in config.services) {
-    services[service] = makePlayRulesServiceFactory(service, config.services[service]);
+    services[service] = makePlayRulesServiceFactory(service, config.services[service], playInformationServiceFactory);
   }
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
       "@cody-engine/contribution": ["packages/contribution/src"],
       "@cody-engine/contribution/*": ["packages/contribution/src/*"],
       "@cody-play/*": ["packages/play/src/*"],
+      "@cody-play/package/*": ["packages/play/src/*"],
       "@event-engine/descriptions/*": ["packages/descriptions/src/lib/*"],
       "@event-engine/infrastructure/*": ["packages/infrastructure/src/lib/*"],
       "@event-engine/messaging/*": ["packages/messaging/src/lib/*"],


### PR DESCRIPTION
This PR adds the possibility to import a playshot into FE and BE to skip the code generation step.

It enables a configuration-driven approach that still offers the same customization options e.g. override handlers, resolvers, UI components etc.

It's optional plug in. Cody generated components override playshot components and custom components can override both. 