### PR TITLE
Fix empty valList behavior of anyOf and arrayIntersect Filter

### DIFF
--- a/packages/infrastructure/src/lib/DocumentStore/InMemory/InMemoryFilterProcessor.ts
+++ b/packages/infrastructure/src/lib/DocumentStore/InMemory/InMemoryFilterProcessor.ts
@@ -126,7 +126,7 @@ export class InMemoryFilterProcessor implements FilterProcessor {
       const value = getValueFromPath(filter.prop, doc);
 
       if (filter.valList.length === 0) {
-        return true;
+        return false;
       }
 
       return filter.valList.some((item) => value.includes(item));

--- a/packages/infrastructure/src/lib/DocumentStore/Postgres/PostgresFilterProcessor.ts
+++ b/packages/infrastructure/src/lib/DocumentStore/Postgres/PostgresFilterProcessor.ts
@@ -134,7 +134,7 @@ export class PostgresFilterProcessor implements FilterProcessor {
       options.push(`$${argumentRef}`);
     });
     if (options.length === 0) {
-      return 'TRUE';
+      return 'FALSE';
     }
 
     const propPath = this.propToJsonPath(filter.prop);
@@ -144,7 +144,7 @@ export class PostgresFilterProcessor implements FilterProcessor {
 
   processArrayIntersectFilter(filter: ArrayIntersectFilter): string {
     if (filter.valList.length === 0) {
-      return 'TRUE';
+      return 'FALSE';
     }
 
     const argumentRef = this.registerArgument(filter.valList);


### PR DESCRIPTION
In https://github.com/proophboard/cody-engine/pull/184 I introduced a wrong behavior for the AnyOf/ArrayIntersect filters when an empty List is passed to compare against. We should explicitly return FALSE in those cases instead of returning all entries, causing potential data leaks that are hart to find and debug because the behavior is not expected.